### PR TITLE
support multiple queries for a single graph

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Keep datadog monitors/dashboards/etc in version control, avoid chaotic managemen
 <!-- CUT only make changes to template/Readme.md -->
 ## Install
 
- - create a new private `kennel` repo for your organization, clone this repo, push the contents of the `template` folder into the private repo 
+ - create a new private `kennel` repo for your organization, clone this repo, push the contents of the `template` folder into the private repo
  - uncomment `.travis.yml` section for automated github PR feedback and datadog updates on merge
  - setup travis build for the repo
  - add a basic projects and teams so others can copy-paste to get started
@@ -104,6 +104,11 @@ Keep datadog monitors/dashboards/etc in version control, avoid chaotic managemen
                 [
                   # title, viz, type, query, edit an existing graph and see the json definition
                   "Graph name", "timeseries", "area", "sum:mystats.foobar{$environment}"
+                ],
+                [
+                  # queries can be an Array as well, this will generate multiple requests
+                  # for a single graph
+                  "Graph name", "timeseries", "area", ["sum:mystats.foobar{$environment}", "sum:mystats.success{$environment}"]
                 ]
               ]
             }

--- a/lib/kennel/models/dash.rb
+++ b/lib/kennel/models/dash.rb
@@ -76,7 +76,9 @@ module Kennel
 
       def render_graphs
         all = definitions.map do |title, viz, type, query|
-          { title: title, definition: { viz: viz, requests: [{ q: query, type: type }] } }
+          queries = query.is_a?(Array) ? query : [query]
+          requests = queries.map { |q| { q: q, type: type } }
+          { title: title, definition: { viz: viz, requests: requests } }
         end + graphs
 
         all.each do |g|

--- a/test/kennel/models/dash_test.rb
+++ b/test/kennel/models/dash_test.rb
@@ -83,6 +83,28 @@ describe Kennel::Models::Dash do
       )
     end
 
+    it "adds definitions as graphs with multiple queries" do
+      dash(
+        definitions: -> { [["TI", "V", "TY", ["Q", "Q2"]]] }
+      ).as_json.must_equal(
+        expected_json.merge(
+          graphs: [
+            {
+              title: "TI",
+              definition: {
+                viz: "V",
+                requests: [
+                  { q: "Q", type: "TY", conditional_formats: [] },
+                  { q: "Q2", type: "TY", conditional_formats: [] }
+                ],
+                autoscale: true
+              }
+            }
+          ]
+        )
+      )
+    end
+
     it "expands template_variables" do
       dash(
         template_variables: -> { ["foo"] }


### PR DESCRIPTION
Kept supporting queries as a `String` for backwards compat