### PR TITLE
Keep widget board_id.

### DIFF
--- a/lib/kennel/models/screen.rb
+++ b/lib/kennel/models/screen.rb
@@ -52,7 +52,6 @@ module Kennel
         actual.delete(:height)
         actual.delete(:width)
         actual[:template_variables] ||= []
-        actual[:widgets].each { |w| w.delete :board_id }
         super
       end
 


### PR DESCRIPTION
@grosser 

## Description

Two issues ->

1. When I copy/pasted my existing screenboard from Datadog API response into the `zendesk_channels` kennel project, some of the widgets included `board_id`. This was excluded from the Datadog API response by kennel, so the diff always showed that I was setting board_id from `nil` to some value when it already had that value in Datadog.

2. When there are no widgets on the screenboard, you get this error -> https://github.com/zendesk/kennel/pull/147#commitcomment-28908698.

This PR adds board_id back into the diff (problem 1) and as a by-product fixes (2).