### PR TITLE
do not compare or send screen widget board_id since it is useless

### DIFF
--- a/lib/kennel/models/screen.rb
+++ b/lib/kennel/models/screen.rb
@@ -69,6 +69,7 @@ module Kennel
             tile.fetch(:requests).each { |r| r[:conditional_formats] ||= [] }
             tile[:autoscale] = true unless widget[:tile_def].key?(:autoscale)
           end
+          widget.delete :board_id
           widget
         end
       end

--- a/test/kennel/models/screen_test.rb
+++ b/test/kennel/models/screen_test.rb
@@ -21,6 +21,7 @@ describe Kennel::Models::Screen do
       widgets: []
     }
   end
+  let(:default_widget) { { title_size: 16, title_align: "left", height: 20, width: 30 }.freeze }
 
   describe "#as_json" do
     it "renders" do
@@ -91,6 +92,10 @@ describe Kennel::Models::Screen do
       s = screen
       s.as_json.object_id.must_equal s.as_json.object_id
     end
+
+    it "does not render board_id to avoid useless diff when user copy-pasted api reply" do
+      screen(widgets: -> { [{ board_id: 123 }] }).as_json.must_equal(expected_json.merge(widgets: [default_widget]))
+    end
   end
 
   describe "#diff" do
@@ -98,7 +103,11 @@ describe Kennel::Models::Screen do
       screen.diff(expected_json).must_be_nil
     end
 
-    it "does not compare read-only fields" do
+    it "does not compare read-only widget board_id field" do
+      screen(widgets: -> { [{ board_id: 123 }] }).diff(expected_json.merge(widgets: [default_widget.dup])).must_be_nil
+    end
+
+    it "does not compare read-only disableCog field" do
       screen.diff(expected_json.merge(disableCog: true)).must_be_nil
     end
 


### PR DESCRIPTION
fixes https://github.com/grosser/kennel/pull/19/files

usecase is that a user copy-pasted the api replies and expects there to be no diff
to make future updates not be annoying