### PR TITLE
Set better defaults for require_full_window option

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -26,8 +26,7 @@ module Kennel
         tags: -> { @project.tags },
         multi: ->  { type != "query alert" || query.include?(" by ") },
         critical_recovery: -> { nil },
-        warning_recovery: -> { nil },
-        require_full_window: -> { require_full_window_default(type, query) }
+        warning_recovery: -> { nil }
       )
 
       attr_reader :project
@@ -129,12 +128,10 @@ module Kennel
 
       private
 
-      def require_full_window_default(type, query)
-        return true unless type == "query alert"
+      def require_full_window
         # default 'on_average', 'at_all_times', 'in_total' aggregations to true, otherwise false
         # https://docs.datadoghq.com/ap/#create-a-monitor
-        regex = /\A(avg|min|sum)/
-        query =~ regex ? true : false
+        type != "query alert" || query.start_with?("avg", "min", "sum")
       end
 
       def validate_json(data)

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -27,7 +27,7 @@ module Kennel
         multi: ->  { type != "query alert" || query.include?(" by ") },
         critical_recovery: -> { nil },
         warning_recovery: -> { nil },
-        require_full_window: -> { true }
+        require_full_window: -> { require_full_window_default(type, query) }
       )
 
       attr_reader :project
@@ -128,6 +128,14 @@ module Kennel
       end
 
       private
+
+      def require_full_window_default(type, query)
+        return true unless type == "query alert"
+        # default 'on_average', 'at_all_times', 'in_total' aggregations to true, otherwise false
+        # https://docs.datadoghq.com/ap/#create-a-monitor
+        regex = /\A(avg|min|sum)/
+        query =~ regex ? true : false
+      end
 
       def validate_json(data)
         type = data.fetch(:type)

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -250,32 +250,74 @@ describe Kennel::Models::Monitor do
     end
   end
 
-  describe '#require_full_window_default' do
+  describe '#require_full_window' do
     describe 'when query alert' do
-      let(:type) { 'query alert' }
-
       it 'returns true for on_average query' do
-        assert_equal true, monitor.send(:require_full_window_default, type, 'avg(last_5m) > 1' )
+        monitor = Kennel::Models::Monitor.new(
+          project,
+          {
+            kennel_id: -> { "m2" },
+            query: -> { "avg(last_5m) > #{critical}" },
+            critical: -> { 123.0 }
+          }
+        )
+
+        assert_equal true, monitor.as_json[:options][:require_full_window]
       end
 
       it 'returns true for at_all_times query' do
-        assert_equal true, monitor.send(:require_full_window_default, type, 'min(last_5m) > 1' )
+        monitor = Kennel::Models::Monitor.new(
+          project,
+          {
+            kennel_id: -> { "m2" },
+            query: -> { "min(last_5m) > #{critical}" },
+            critical: -> { 123.0 }
+          }
+        )
+
+        assert_equal true, monitor.as_json[:options][:require_full_window]
       end
 
       it 'returns true for in_total query' do
-        assert_equal true, monitor.send(:require_full_window_default, type, 'sum(last_5m) > 1' )
+        monitor = Kennel::Models::Monitor.new(
+          project,
+          {
+            kennel_id: -> { "m2" },
+            query: -> { "sum(last_5m) > #{critical}" },
+            critical: -> { 123.0 }
+          }
+        )
+
+        assert_equal true, monitor.as_json[:options][:require_full_window]
       end
 
       it 'returns false for at_least_once query' do
-        assert_equal false, monitor.send(:require_full_window_default, type, 'max(last_5m) > 1' )
+        monitor = Kennel::Models::Monitor.new(
+          project,
+          {
+            kennel_id: -> { "m2" },
+            query: -> { "max(last_5m) > #{critical}" },
+            critical: -> { 123.0 }
+          }
+        )
+
+        assert_equal false, monitor.as_json[:options][:require_full_window]
       end
     end
 
     describe 'when not a query alert' do
-      let(:type) { 'service check' }
-
       it 'returns true' do
-        assert_equal true, monitor.send(:require_full_window_default, type, 'max(last_5m) > 1' )
+        monitor = Kennel::Models::Monitor.new(
+          project,
+          {
+            kennel_id: -> { "m2" },
+            query: -> { "sum(last_5m) > #{critical}" },
+            critical: -> { 123 },
+            type: -> { "service check" }
+          }
+        )
+
+        assert_equal true, monitor.as_json[:options][:require_full_window]
       end
     end
   end

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -250,71 +250,61 @@ describe Kennel::Models::Monitor do
     end
   end
 
-  describe '#require_full_window' do
-    describe 'when query alert' do
-      it 'returns true for on_average query' do
+  describe "#require_full_window" do
+    describe "when query alert" do
+      it "returns true for on_average query" do
         monitor = Kennel::Models::Monitor.new(
           project,
-          {
-            kennel_id: -> { "m2" },
-            query: -> { "avg(last_5m) > #{critical}" },
-            critical: -> { 123.0 }
-          }
+          kennel_id: -> { "m2" },
+          query: -> { "avg(last_5m) > #{critical}" },
+          critical: -> { 123.0 }
         )
 
         assert_equal true, monitor.as_json[:options][:require_full_window]
       end
 
-      it 'returns true for at_all_times query' do
+      it "returns true for at_all_times query" do
         monitor = Kennel::Models::Monitor.new(
           project,
-          {
-            kennel_id: -> { "m2" },
-            query: -> { "min(last_5m) > #{critical}" },
-            critical: -> { 123.0 }
-          }
+          kennel_id: -> { "m2" },
+          query: -> { "min(last_5m) > #{critical}" },
+          critical: -> { 123.0 }
         )
 
         assert_equal true, monitor.as_json[:options][:require_full_window]
       end
 
-      it 'returns true for in_total query' do
+      it "returns true for in_total query" do
         monitor = Kennel::Models::Monitor.new(
           project,
-          {
-            kennel_id: -> { "m2" },
-            query: -> { "sum(last_5m) > #{critical}" },
-            critical: -> { 123.0 }
-          }
+          kennel_id: -> { "m2" },
+          query: -> { "sum(last_5m) > #{critical}" },
+          critical: -> { 123.0 }
         )
 
         assert_equal true, monitor.as_json[:options][:require_full_window]
       end
 
-      it 'returns false for at_least_once query' do
+      it "returns false for at_least_once query" do
         monitor = Kennel::Models::Monitor.new(
           project,
-          {
-            kennel_id: -> { "m2" },
-            query: -> { "max(last_5m) > #{critical}" },
-            critical: -> { 123.0 }
-          }
+          kennel_id: -> { "m2" },
+          query: -> { "max(last_5m) > #{critical}" },
+          critical: -> { 123.0 }
         )
 
         assert_equal false, monitor.as_json[:options][:require_full_window]
       end
     end
 
-    describe 'when not a query alert' do
-      it 'returns true' do
+    describe "when not a query alert" do
+      it "returns true" do
         monitor = Kennel::Models::Monitor.new(
           project,
-          {
-            kennel_id: -> { "m2" },
-            query: -> { "sum(last_5m) > #{critical}" },
-            critical: -> { 123 },
-            type: -> { "service check" }
-          }
+          kennel_id: -> { "m2" },
+          query: -> { "sum(last_5m) > #{critical}" },
+          critical: -> { 123 },
+          type: -> { "service check" }
         )
 
         assert_equal true, monitor.as_json[:options][:require_full_window]


### PR DESCRIPTION
For query alerts, set default `require_full_window` option to true for “on average”, “at all times” and “in total” aggregations, otherwise false. This follows DataDogs recommendation (see below). Non query alerts are always set to true which is the current behavior.

> require_full_window a boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly recommend you set this to False for sparse metrics, otherwise some evaluations are skipped. Default: True for “on average”, “at all times” and “in total” aggregation. False otherwise.

 -- https://docs.datadoghq.com/api/?lang=python#monitors

@grosser 