### PR TITLE
Prevent resources getting filtered from DD when using project filter

### DIFF
--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -54,11 +54,7 @@ module Kennel
     def calculate_diff
       @update = []
       @delete = []
-
-      actual = Progress.progress "Downloading definitions" do
-        download_definitions
-      end
-      actual.select! { |a| tracking_id(a)&.start_with?("#{@project_filter}:") } if @project_filter
+      actual = filtered_resources_from_dd
 
       Progress.progress "Diffing" do
         details_cache do |cache|
@@ -181,6 +177,19 @@ module Kennel
 
     def tracking_field(a)
       a[:message] ? :message : :description
+    end
+
+    def filtered_resources_from_dd
+      Progress.progress "Downloading definitions" do
+        download_definitions.select do |a|
+          if @project_filter
+            tracking_id = tracking_id(a)
+            tracking_id.nil? || tracking_id.start_with?("#{@project_filter}:")
+          else
+            true
+          end
+        end
+      end
     end
   end
 end

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -54,7 +54,9 @@ module Kennel
     def calculate_diff
       @update = []
       @delete = []
-      actual = filtered_resources_from_dd
+      actual = Progress.progress "Downloading definitions" do
+        filtered_resources_from_dd
+      end
 
       Progress.progress "Diffing" do
         details_cache do |cache|
@@ -180,14 +182,12 @@ module Kennel
     end
 
     def filtered_resources_from_dd
-      Progress.progress "Downloading definitions" do
-        download_definitions.select do |a|
-          if @project_filter
-            tracking_id = tracking_id(a)
-            tracking_id.nil? || tracking_id.start_with?("#{@project_filter}:")
-          else
-            true
-          end
+      download_definitions.select do |a|
+        if @project_filter
+          tracking_id = tracking_id(a)
+          tracking_id.nil? || tracking_id.start_with?("#{@project_filter}:")
+        else
+          true
         end
       end
     end

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -70,7 +70,8 @@ describe Kennel::Syncer do
   let(:dashes) { [] }
   let(:screens) { [] }
   let(:expected) { [] }
-  let(:syncer) { Kennel::Syncer.new(api, expected) }
+  let(:project_filter) { nil }
+  let(:syncer) { Kennel::Syncer.new(api, expected, project: project_filter) }
 
   before do
     Kennel::Progress.stubs(:print).yields
@@ -126,6 +127,20 @@ describe Kennel::Syncer do
           ~nested.foo \"baz\" -> \"bar\"
           +bar nil -> \"foo\"
       TEXT
+    end
+
+    describe("with project filter set") do
+      let(:project_filter) { "a" }
+
+      it "updates when previously unmanaged" do
+        expected << monitor("a", "b", id: 123)
+        monitors << component("a", "", id: 123, message: "old stuff")
+        output.must_equal <<~TEXT
+        Plan:
+        Update a:b
+          ~message \"old stuff\" -> \"@slack-foo\\n-- Managed by kennel a:b in test/test_helper.rb, do not modify manually\"
+        TEXT
+      end
     end
 
     it "shows long updates nicely" do

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -136,9 +136,9 @@ describe Kennel::Syncer do
         expected << monitor("a", "b", id: 123)
         monitors << component("a", "", id: 123, message: "old stuff")
         output.must_equal <<~TEXT
-        Plan:
-        Update a:b
-          ~message \"old stuff\" -> \"@slack-foo\\n-- Managed by kennel a:b in test/test_helper.rb, do not modify manually\"
+          Plan:
+          Update a:b
+            ~message \"old stuff\" -> \"@slack-foo\\n-- Managed by kennel a:b in test/test_helper.rb, do not modify manually\"
         TEXT
       end
     end


### PR DESCRIPTION
Symptoms are seen when migrating an existing monitor/dashboard into Kennel and then trying to update it from the cmdline.
```
$ PROJECT=doorman bundle exec rake kennel:update_datadog
Generating ... 0.13s
Downloading definitions ... 1.36s
Diffing ... -rake aborted!
Unable to find existing dash with id 52264
```

Problem is that since this dashboard wasn't managed by kennel previously it was missing the tracking kennel id text and so it got filtered out by Kennel.
Now we don't filter if there was no tracking-id.