### PR TITLE
validate that only available dimensions are used in is_match

### DIFF
--- a/lib/kennel/models/base.rb
+++ b/lib/kennel/models/base.rb
@@ -95,6 +95,10 @@ module Kennel
         "#{project.kennel_id}:#{kennel_id}"
       end
 
+      def to_json
+        raise NotImplementedError, "Use as_json"
+      end
+
       private
 
       # discard styles/conditional_formats/aggregator if nothing would change when we applied (both are default or nil)

--- a/test/kennel/models/base_test.rb
+++ b/test/kennel/models/base_test.rb
@@ -224,4 +224,10 @@ describe Kennel::Models::Base do
       base.tracking_id.must_equal "test_project:test_base"
     end
   end
+
+  describe ".to_json" do
+    it "blows up when used by accident instead of rendering unexpected json" do
+      assert_raises(NotImplementedError) { TestBase.new.to_json }
+    end
+  end
 end


### PR DESCRIPTION
`Kennel::Models::Base::ValidationError: foo:bar is_match used with unsupported dimensions ["environment"], allowed dimenions are ["pod"]`