### PR TITLE
sometimes datadog returns empty time object, which creates perma-diff

### DIFF
--- a/lib/kennel/models/base.rb
+++ b/lib/kennel/models/base.rb
@@ -104,13 +104,19 @@ module Kennel
       # discard styles/conditional_formats/aggregator if nothing would change when we applied (both are default or nil)
       def ignore_request_defaults(expected, actual, level1, level2)
         expected[level1].each_with_index do |e_w, wi|
-          (e_w.dig(level2, :requests) || []).each_with_index do |e_r, ri|
-            next unless a_r = actual.dig(level1, wi, level2, :requests, ri) # skip newly added widgets/requests
-            REQUEST_DEFAULTS.each do |key, default|
-              if [a_r, e_r].all? { |r| r[key].nil? || r[key] == default }
-                a_r.delete(key)
-                e_r.delete(key)
-              end
+          e_r = e_w.dig(level2, :requests) || []
+          a_r = actual.dig(level1, wi, level2, :requests) || []
+          ignore_defaults e_r, a_r, REQUEST_DEFAULTS
+        end
+      end
+
+      def ignore_defaults(expected, actual, defaults)
+        expected.each_with_index do |e, i|
+          next unless a = actual[i] # skip newly added
+          defaults.each do |key, default|
+            if [a, e].all? { |r| r[key].nil? || r[key] == default }
+              a.delete(key)
+              e.delete(key)
             end
           end
         end

--- a/lib/kennel/models/screen.rb
+++ b/lib/kennel/models/screen.rb
@@ -6,6 +6,7 @@ module Kennel
       include OptionalValidations
 
       API_LIST_INCOMPLETE = true
+      COPIED_WIDGET_VALUES = [:board_id, :isShared].freeze
 
       settings :id, :board_title, :description, :widgets, :kennel_id
 
@@ -61,8 +62,7 @@ module Kennel
           # api randomly returns time.live_span or timeframe
           w[:timeframe] = w.delete(:time)[:live_span] if w[:time]
 
-          w.delete :board_id # copied value, can ignore
-          w.delete :isShared # copied value, can ignore
+          COPIED_WIDGET_VALUES.each { |v| w.delete v }
         end
 
         ignore_request_defaults as_json, actual, :widgets, :tile_def
@@ -79,7 +79,7 @@ module Kennel
       def validate_json(data)
         # check for fields that are unsettable
         data[:widgets].each do |w|
-          [:isShared, :board_id].each do |ignored|
+          COPIED_WIDGET_VALUES.each do |ignored|
             if w.key?(ignored)
               invalid! "remove definition #{ignored}, it is unsettable and will always produce a diff"
             end

--- a/lib/kennel/models/screen.rb
+++ b/lib/kennel/models/screen.rb
@@ -7,6 +7,10 @@ module Kennel
 
       API_LIST_INCOMPLETE = true
       COPIED_WIDGET_VALUES = [:board_id, :isShared].freeze
+      WIDGET_DEFAULTS = {
+        time: {},
+        timeframe: "1h"
+      }.freeze
 
       settings :id, :board_title, :description, :widgets, :kennel_id
 
@@ -59,12 +63,15 @@ module Kennel
         actual.delete(:showGlobalTimeOnboarding)
         actual[:template_variables] ||= []
         (actual[:widgets] || []).each do |w|
-          # api randomly returns time.live_span or timeframe
-          w[:timeframe] = w.delete(:time)[:live_span] if w[:time]
+          # api randomly returns time.live_span or timeframe or empty time hash
+          if w.dig(:time, :live_span)
+            w[:timeframe] = w[:time].delete(:live_span)
+          end
 
           COPIED_WIDGET_VALUES.each { |v| w.delete v }
         end
 
+        ignore_defaults as_json[:widgets], actual[:widgets], WIDGET_DEFAULTS
         ignore_request_defaults as_json, actual, :widgets, :tile_def
 
         super
@@ -119,8 +126,7 @@ module Kennel
             {
               title: true,
               legend: false,
-              legend_size: "0",
-              timeframe: "1h"
+              legend_size: "0"
             }
           else
             {}

--- a/test/kennel/models/screen_test.rb
+++ b/test/kennel/models/screen_test.rb
@@ -32,7 +32,6 @@ describe Kennel::Models::Screen do
           title: true,
           legend: false,
           legend_size: "0",
-          timeframe: "1h",
           title_text: "Hello",
           type: "timeseries",
           x: 0,
@@ -53,29 +52,29 @@ describe Kennel::Models::Screen do
     )
   end
   let(:default_widget) { { title_size: 16, title_align: "left", height: 20, width: 30 }.freeze }
-  let(:timeseries_widget) do
-    {
-      widgets: -> {
-        [
-          {
-            title_text: "Hello",
-            type: "timeseries",
-            x: 0,
-            y: 0,
-            tile_def: {
-              viz: "timeseries",
-              requests: [
-                {
-                  q: "avg:foo.bar",
-                  aggregator: "avg",
-                  type: "area"
-                }
-              ]
+  let(:timeseries_widgets) do
+    [
+      {
+        title_text: "Hello",
+        type: "timeseries",
+        x: 0,
+        y: 0,
+        tile_def: {
+          viz: "timeseries",
+          requests: [
+            {
+              q: "avg:foo.bar",
+              aggregator: "avg",
+              type: "area"
             }
-          }
-        ]
+          ]
+        }
       }
-    }
+    ]
+  end
+  let(:timeseries_widget) do
+    w = timeseries_widgets
+    { widgets: -> { w } }
   end
 
   describe "#as_json" do
@@ -149,6 +148,12 @@ describe Kennel::Models::Screen do
     it "does not show diff when api randomly returns time.live_span instead of timeframe" do
       expected_json_timeseries[:widgets][0].delete :timeframe
       expected_json_timeseries[:widgets][0][:time] = { live_span: "1h" }
+      screen(timeseries_widget).diff(expected_json_timeseries).must_equal []
+    end
+
+    it "does not show diff when api randomly returns empty time" do
+      timeseries_widgets[0][:time] = {}
+      expected_json_timeseries[:widgets][0][:time] = {}
       screen(timeseries_widget).diff(expected_json_timeseries).must_equal []
     end
 


### PR DESCRIPTION
/fyi @adammw