### PR TITLE
Allow setting `evaluation_delay`

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -11,12 +11,13 @@ module Kennel
       NON_MULTI_TYPES = ["query alert", "log alert"].freeze # NOTE: event alerts don't seem to return their multi setting
 
       settings(
-        :query, :name, :message, :escalation_message, :critical, :kennel_id, :type, :renotify_interval, :warning,
+        :query, :name, :message, :escalation_message, :evaluation_delay, :critical, :kennel_id, :type, :renotify_interval, :warning,
         :ok, :id, :no_data_timeframe, :notify_no_data, :notify_audit, :tags, :multi, :critical_recovery, :warning_recovery, :require_full_window
       )
       defaults(
         message: -> { "\n\n@slack-#{project.team.slack}" },
         escalation_message: -> { "" },
+        evaluation_delay:  -> { 0 },
         type: -> { "query alert" },
         renotify_interval: -> { 120 },
         warning: -> { nil },
@@ -56,7 +57,7 @@ module Kennel
             new_host_delay: 300,
             include_tags: true,
             escalation_message: Utils.presence(escalation_message.strip),
-            evaluation_delay: nil,
+            evaluation_delay: evaluation_delay,
             locked: false, # setting this to true prevents any edit and breaks updates when using replace workflow
             renotify_interval: renotify_interval || 0,
             thresholds: {

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -41,7 +41,7 @@ describe Kennel::Models::Monitor do
         new_host_delay: 300,
         include_tags: true,
         escalation_message: nil,
-        evaluation_delay: nil,
+        evaluation_delay: 0,
         locked: false,
         renotify_interval: 120,
         thresholds: { critical: 123.0 }
@@ -155,6 +155,10 @@ describe Kennel::Models::Monitor do
       monitor(notify_audit: -> { false }).as_json.dig(:options, :notify_audit).must_equal false
     end
 
+    it "can set evaluation_delay" do
+      monitor(evaluation_delay: -> { 20 }).as_json.dig(:options, :evaluation_delay).must_equal 20
+    end
+
     it "is cached so we can modify it in syncer" do
       m = monitor
       m.as_json[:foo] = 1
@@ -219,11 +223,6 @@ describe Kennel::Models::Monitor do
 
     it "ignores missing escalation_message" do
       expected_basic_json[:options].delete(:escalation_message)
-      diff_resource({}, {}).must_equal []
-    end
-
-    it "ignores missing evaluation_delay" do
-      expected_basic_json[:options].delete(:evaluation_delay)
       diff_resource({}, {}).must_equal []
     end
 


### PR DESCRIPTION
Allow setting `evaluation_delay`. Useful for AWS metrics and recommended by Datadog:

![screen shot 2018-09-10 at 13 41 01](https://user-images.githubusercontent.com/415393/45295530-51fd1200-b4ff-11e8-94ef-8aef8291a469.png)

@grosser 