### PR TITLE
Project model should add a project tag

### DIFF
--- a/lib/kennel/models/project.rb
+++ b/lib/kennel/models/project.rb
@@ -4,7 +4,7 @@ module Kennel
     class Project < Base
       settings :team, :parts, :tags, :slack
       defaults(
-        tags: -> { ["project:#{kennel_id}"] + team.tags },
+        tags: -> { Array(["project:#{kennel_id}"] + team.tags).uniq },
         slack: -> { team.slack }
       )
 

--- a/lib/kennel/models/project.rb
+++ b/lib/kennel/models/project.rb
@@ -4,7 +4,7 @@ module Kennel
     class Project < Base
       settings :team, :parts, :tags, :slack
       defaults(
-        tags: -> { ["service:#{kennel_id}"] + team.tags },
+        tags: -> { ["project:#{kennel_id}"] + team.tags },
         slack: -> { team.slack }
       )
 

--- a/lib/kennel/models/project.rb
+++ b/lib/kennel/models/project.rb
@@ -4,7 +4,8 @@ module Kennel
     class Project < Base
       settings :team, :parts, :tags, :slack
       defaults(
-        tags: -> { (["project:#{kennel_id}"] + team.tags).uniq },
+        # Remove service tag after transitioning existing tools to use the project tag
+        tags: -> { (["project:#{kennel_id}", "service:#{kennel_id}"] + team.tags).uniq },
         slack: -> { team.slack }
       )
 

--- a/lib/kennel/models/project.rb
+++ b/lib/kennel/models/project.rb
@@ -4,7 +4,7 @@ module Kennel
     class Project < Base
       settings :team, :parts, :tags, :slack
       defaults(
-        tags: -> { Array(["project:#{kennel_id}"] + team.tags).uniq },
+        tags: -> { (["project:#{kennel_id}"] + team.tags).uniq },
         slack: -> { team.slack }
       )
 

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -31,7 +31,7 @@ describe Kennel::Models::Monitor do
       type: "query alert",
       query: +"avg(last_5m) > 123.0",
       message: "@slack-foo",
-      tags: ["service:test_project", "team:test_team"],
+      tags: ["project:test_project", "team:test_team"],
       options: {
         timeout_h: 0,
         notify_no_data: true,

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -31,7 +31,7 @@ describe Kennel::Models::Monitor do
       type: "query alert",
       query: +"avg(last_5m) > 123.0",
       message: "@slack-foo",
-      tags: ["project:test_project", "team:test_team"],
+      tags: ["project:test_project", "service:test_project", "team:test_team"],
       options: {
         timeout_h: 0,
         notify_no_data: true,

--- a/test/kennel/models/project_test.rb
+++ b/test/kennel/models/project_test.rb
@@ -12,7 +12,7 @@ describe Kennel::Models::Project do
 
   describe "#tags" do
     it "adds itself by default" do
-      TestProject.new.tags.must_equal ["service:test_project", "team:test_team"]
+      TestProject.new.tags.must_equal ["project:test_project", "team:test_team"]
     end
   end
 

--- a/test/kennel/models/project_test.rb
+++ b/test/kennel/models/project_test.rb
@@ -12,7 +12,7 @@ describe Kennel::Models::Project do
 
   describe "#tags" do
     it "adds itself by default" do
-      TestProject.new.tags.must_equal ["project:test_project", "team:test_team"]
+      TestProject.new.tags.must_equal ["project:test_project", "service:test_project", "team:test_team"]
     end
   end
 

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -13,7 +13,7 @@ describe Kennel::Syncer do
 
   def component(pid, cid, extra = {})
     {
-      tags: extra.delete(:tags) || ["project:a", "team:test_team"],
+      tags: extra.delete(:tags) || ["project:a", "service:a", "team:test_team"],
       message: "@slack-foo\n-- Managed by kennel #{pid}:#{cid} in test/test_helper.rb, do not modify manually",
       options: {}
     }.merge(extra)

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -13,7 +13,7 @@ describe Kennel::Syncer do
 
   def component(pid, cid, extra = {})
     {
-      tags: extra.delete(:tags) || ["service:a", "team:test_team"],
+      tags: extra.delete(:tags) || ["project:a", "team:test_team"],
       message: "@slack-foo\n-- Managed by kennel #{pid}:#{cid} in test/test_helper.rb, do not modify manually",
       options: {}
     }.merge(extra)


### PR DESCRIPTION
The tag key name applied by a model's `defaults` should match the model class name.  It makes more sense that the Project model adds a `project` tag.