### PR TITLE
also show monitors that are alerting but do not have a grouping

### DIFF
--- a/lib/kennel/unmuted_alerts.rb
+++ b/lib/kennel/unmuted_alerts.rb
@@ -57,6 +57,12 @@ module Kennel
           end
         end
 
+        # add fake group to monitors without groups so filtering below works as expected and we show something
+        monitors.each do |m|
+          next if m[:state][:groups].any? || m[:overall_state] == "No Data"
+          m[:state][:groups][:default] = { name: "default", status: m[:overall_state] }
+        end
+
         # only keep groups that are alerting
         monitors.each { |m| m[:state][:groups].reject! { |_, g| g[:status] == "OK" } }
 

--- a/test/kennel/unmuted_alerts_test.rb
+++ b/test/kennel/unmuted_alerts_test.rb
@@ -116,5 +116,18 @@ describe Kennel::UnmutedAlerts do
     it "only keeps alerting groups in monitor" do
       result.first[:state][:groups].size.must_equal 2
     end
+
+    describe "when monitor has no grouping" do
+      before { monitor[:state][:groups].clear }
+
+      it "uses a fake group" do
+        result.first[:state][:groups].must_equal [{ name: "default", status: "Alert" }]
+      end
+
+      it "ignores No Data" do
+        monitor[:overall_state] = "No Data"
+        result.size.must_equal 0
+      end
+    end
   end
 end


### PR DESCRIPTION
```
bundle exec rake kennel:alerts TAG=test:true
Downloading ... 4.88s
Getting monitor details ... 0.38s
TEST No-data
https://app.datadoghq.com/monitors/1234
No Data  default
```

.... this might be a bad idea ... parking it here ...