### PR TITLE
allow resolving ids for uptime screens

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -175,6 +175,10 @@ Put returned definition into a project of your choice.
 Some validations might be too strict for your usecase or just wrong, please [open an issue](https://github.com/grosser/kennel/issues) and
 to unblock use the `validate: -> { false }` option.
 
+### Linking with kennel_ids
+
+Screens `uptime` widgets can use `monitor: {id: "foo:bar"}` to link to existing monitors via their kennel_id
+
 ### Debugging locally
 
  - make sure to be on update `master` to not undo other changes

--- a/lib/kennel/models/base.rb
+++ b/lib/kennel/models/base.rb
@@ -131,6 +131,9 @@ module Kennel
         raise NotImplementedError, "Use as_json"
       end
 
+      def resolve_linked_tracking_ids(*)
+      end
+
       private
 
       # let users know which project/resource failed when something happens during diffing where the backtrace is hidden

--- a/lib/kennel/models/screen.rb
+++ b/lib/kennel/models/screen.rb
@@ -84,6 +84,16 @@ module Kennel
         Utils.path_to_url "/screen/#{id}"
       end
 
+      def resolve_linked_tracking_ids(id_map)
+        uptime_widgets = as_json[:widgets].select { |w| w[:type] == "uptime" && w.dig(:monitor, :id).is_a?(String) }
+        uptime_widgets.each do |uptime_widget|
+          tracking = uptime_widget[:monitor][:id]
+          uptime_widget[:monitor][:id] =
+            id_map[tracking] ||
+            warn("Unable to find #{tracking} in existing monitors (they need to be created first to link them)")
+        end
+      end
+
       private
 
       def validate_json(data)

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -56,7 +56,10 @@ module Kennel
     def calculate_diff
       @update = []
       @delete = []
+
       actual = Progress.progress("Downloading definitions") { download_definitions }
+
+      resolve_linked_tracking_ids actual
 
       Progress.progress "Diffing" do
         filter_by_project! actual
@@ -175,6 +178,11 @@ module Kennel
         Updates with PROJECT= filter should not update #{TRACKING_FIELDS.join("/")} of resources with a set `id:`, since this makes them get deleted by a full update.
         Remove the `id:` to test them out, which will result in a copy being created and later deleted.
       TEXT
+    end
+
+    def resolve_linked_tracking_ids(actual)
+      map = actual.each_with_object({}) { |a, lookup| lookup[tracking_id(a)] = a.fetch(:id) }
+      @expected.each { |e| e.resolve_linked_tracking_ids(map) }
     end
 
     def filter_by_project!(definitions)

--- a/template/Readme.md
+++ b/template/Readme.md
@@ -157,6 +157,10 @@ Put returned definition into a project of your choice.
 Some validations might be too strict for your usecase or just wrong, please [open an issue](https://github.com/grosser/kennel/issues) and
 to unblock use the `validate: -> { false }` option.
 
+### Linking with kennel_ids
+
+Screens `uptime` widgets can use `monitor: {id: "foo:bar"}` to link to existing monitors via their kennel_id
+
 ### Debugging locally
 
  - make sure to be on update `master` to not undo other changes


### PR DESCRIPTION
I removed relative support since it's pretty easy to add `#{project.kennel_id}` manually and makes this feature simpler

@alex-stone