### PR TITLE
ignore ignored alerts since they mean resolved and are not in the UI …

### DIFF
--- a/lib/kennel/unmuted_alerts.rb
+++ b/lib/kennel/unmuted_alerts.rb
@@ -7,8 +7,7 @@ module Kennel
     COLORS = {
       "Alert" => :red,
       "Warn" => :yellow,
-      "No Data" => :cyan,
-      "Ignored" => :magenta # resolved but still broken
+      "No Data" => :cyan
     }.freeze
 
     class << self
@@ -56,7 +55,7 @@ module Kennel
         monitors.reject! { |m| m[:options][:silenced].key?(:*) }
 
         # only keep groups that are alerting
-        monitors.each { |m| m[:state][:groups].reject! { |_, g| g[:status] == "OK" } }
+        monitors.each { |m| m[:state][:groups].reject! { |_, g| g[:status] == "OK" || g[:status] == "Ignored" } }
 
         # only keep alerting groups that are not silenced
         monitors.each do |m|

--- a/test/kennel/unmuted_alerts_test.rb
+++ b/test/kennel/unmuted_alerts_test.rb
@@ -91,6 +91,11 @@ describe Kennel::UnmutedAlerts do
       result.size.must_equal 1
     end
 
+    it "removes monitors that are Ignored since that just means recovered" do
+      monitor[:state][:groups].values.each { |v| v[:status] = "Ignored" }
+      result.size.must_equal 0
+    end
+
     it "removes completely muted alerts" do
       monitor[:options] = { silenced: { "*": "foo" } }
       result.size.must_equal 0


### PR DESCRIPTION
…either

reverts b64ef0e1

saw datadog history show `alerted` / `resolved` and it was still in ignored ... opened a ticket but not expecting help

https://help.datadoghq.com/hc/en-us/requests/178884