### PR TITLE
support alphanumeric ids

### DIFF
--- a/lib/kennel/importer.rb
+++ b/lib/kennel/importer.rb
@@ -18,6 +18,7 @@ module Kennel
 
       data = @api.show(model.api_resource, id)
       data = data[resource.to_sym] || data
+      id = data.fetch(:id) # store numerical id returned from the api
       model.normalize({}, data)
       data[:id] = id
       data[:kennel_id] = "pick_something_descriptive"

--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -53,7 +53,8 @@ namespace :kennel do
   desc "Covert existing resources to copy-pastable definitions to import existing resources RESOURCE=dash ID=1234"
   task import: :environment do
     resource = ENV["RESOURCE"] || abort("Call with RESOURCE=dash") # TODO: add others
-    id = Integer(ENV["ID"] || abort("Call with ID=1234"))
+    id = ENV["ID"] || abort("Call with ID=1234")
+    id = Integer(id) if id =~ /^\d+$/ # dashboards can have alphanumeric ids
     puts Kennel::Importer.new(Kennel.send(:api)).import(resource, id)
   end
 


### PR DESCRIPTION
 - new /dashboards/ UI shows alphanumeric ids
 - old /dash/ UI still works with ids
 - api supports numeric and alphanumeric ids for `show`
 - api does not return alphanumeric id see https://help.datadoghq.com/hc/en-us/requests/202029

@cvgw
/cc @zendesk/compute
