### PR TITLE
nicely format imports

### DIFF
--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -208,6 +208,7 @@ module Kennel
     def add_tracking_id(e)
       json = e.as_json
       field = tracking_field(json)
+      raise "remove \"-- Managed by kennel\" line it from #{field} to copy a resource" if tracking_value(json[field])
       json[field] = "#{json[field]}\n-- Managed by kennel #{e.tracking_id} in #{e.project.class.file_location}, do not modify manually".lstrip
     end
 

--- a/lib/kennel/utils.rb
+++ b/lib/kennel/utils.rb
@@ -15,10 +15,20 @@ module Kennel
 
     class << self
       def snake_case(string)
-        string.gsub(/::/, "_") # Foo::Bar -> foo_bar
+        string
+          .gsub(/::/, "_") # Foo::Bar -> foo_bar
           .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2') # FOOBar -> foo_bar
           .gsub(/([a-z\d])([A-Z])/, '\1_\2') # fooBar -> foo_bar
           .downcase
+      end
+
+      # simplified version of https://apidock.com/rails/ActiveSupport/Inflector/parameterize
+      def parameterize(string)
+        string
+          .downcase
+          .gsub(/[^a-z0-9\-_]+/, "-") # remove unsupported
+          .gsub(/-{2,}/, "-") # remove duplicates
+          .gsub(/^-|-$/, "") # remove leading/trailing
       end
 
       def presence(value)

--- a/test/kennel/utils_test.rb
+++ b/test/kennel/utils_test.rb
@@ -14,6 +14,20 @@ describe Kennel::Utils do
     end
   end
 
+  describe ".parameterize" do
+    {
+      "--" => "",
+      "aøb" => "a-b",
+      "" => "",
+      "a1_Bc" => "a1_bc",
+      "øabcøødefø" => "abc-def"
+    }.each do |from, to|
+      it "coverts #{from} to #{to}" do
+        Kennel::Utils.parameterize(from).must_equal to
+      end
+    end
+  end
+
   describe ".presence" do
     it "returns regular values" do
       Kennel::Utils.presence("a").must_equal "a"


### PR DESCRIPTION
```
Kennel::Models::Monitor.new(
  self,
  name: -> { "foo" },
  id: -> { 123 },
  kennel_id: -> { "foo" },
  type: -> { "query alert" },
  tags: -> { ["foo", "team:bar"] },
  query: -> { "foo > #{critical}" },
  message: -> {
    <<~TEXT
      foo

      bar
    TEXT
  },
  critical: -> { 6.0 },
  notify_no_data: -> { false },
  warning: -> { 4.0 }
)
```