### PR TITLE
use net-http-persistent to speedup multiple requests to the same origin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     kennel (1.34.0)
       faraday
       hashdiff
+      net-http-persistent-retry
 
 GEM
   remote: https://rubygems.org/
@@ -14,6 +15,7 @@ GEM
     bump (0.6.0)
     byebug (10.0.2)
     coderay (1.1.2)
+    connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     faraday (0.15.4)
@@ -28,7 +30,9 @@ GEM
     minitest (5.11.3)
     mocha (1.5.0)
       metaclass (~> 0.0.1)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
+    net-http-persistent-retry (3.0.1)
+      connection_pool (~> 2.2)
     parallel (1.12.1)
     parallel_tests (2.21.3)
       parallel

--- a/kennel.gemspec
+++ b/kennel.gemspec
@@ -13,4 +13,5 @@ Gem::Specification.new name, Kennel::VERSION do |s|
   s.required_ruby_version = ">= 2.5.0"
   s.add_runtime_dependency "faraday"
   s.add_runtime_dependency "hashdiff"
+  s.add_runtime_dependency "net-http-persistent-retry"
 end

--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -4,7 +4,7 @@ module Kennel
     def initialize(app_key, api_key)
       @app_key = app_key
       @api_key = api_key
-      @client = Faraday.new(url: "https://app.datadoghq.com")
+      @client = Faraday.new(url: "https://app.datadoghq.com") { |c| c.adapter :net_http_persistent }
     end
 
     def show(api_resource, id, params = {})
@@ -36,7 +36,7 @@ module Kennel
       tries = 2
 
       tries.times do |i|
-        response = Utils.retry Faraday::ConnectionFailed, times: 2 do
+        response = Utils.retry Faraday::ConnectionFailed, Faraday::TimeoutError, times: 2 do
           @client.send(method, "#{path}?#{query}") do |request|
             request.body = JSON.generate(body) if body
             request.headers["Content-type"] = "application/json"

--- a/test/kennel/api_test.rb
+++ b/test/kennel/api_test.rb
@@ -136,7 +136,7 @@ describe Kennel::Api do
         api.show("monitor", 1234).must_equal foo: "bar"
       end
       assert_requested request, times: 3
-      stderr.string.must_equal "Error execution expired, 1 retries left\nError execution expired, 0 retries left\n"
+      stderr.string.scan(/\d retries left/).must_equal ["1 retries left", "0 retries left"]
     end
 
     it "fails on repeated errors" do


### PR DESCRIPTION
```
20.times do
    Kennel.send(:api).show("monitor", "123")
  end
```
before: 7.5s 
after: 3.1s

this changes error behavior see https://github.com/drbrain/net-http-persistent/issues/89
might also cause issues with parallel execution, but we'll see about that ...