### PR TITLE
not setting an option reverts it to datadogs default value ... which …

### DIFF
--- a/lib/kennel/importer.rb
+++ b/lib/kennel/importer.rb
@@ -36,6 +36,7 @@ module Kennel
         # flatten monitor options so they are all on the base
         data.merge!(data.delete(:options))
         data.merge!(data.delete(:thresholds) || {})
+        [:notify_no_data, :notify_audit].each { |k| data.delete(k) if data[k] } # monitor uses true by default
         data = data.slice(*model.instance_methods)
 
         # make query use critical method if it matches

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -9,15 +9,15 @@ module Kennel
       QUERY_INTERVALS = ["1m", "5m", "10m", "15m", "30m", "1h", "2h", "4h", "1d"].freeze
       OPTIONAL_SERVICE_CHECK_THRESHOLDS = [:ok, :warning].freeze
       READONLY_ATTRIBUTES = Base::READONLY_ATTRIBUTES + [:multi]
+
+      # defaults that datadog uses when options are not sent, so safe to leave out if our values match their defaults
       MONITOR_OPTION_DEFAULTS = {
         evaluation_delay: nil,
         timeout_h: 0,
         renotify_interval: 120,
-        notify_audit: true,
-        notify_no_data: true,
         no_data_timeframe: nil # this works out ok since if notify_no_data is on, it would never be nil
       }.freeze
-      DEFAULT_ESCALATION_MESAGE = ["", nil].freeze
+      DEFAULT_ESCALATION_MESSAGE = ["", nil].freeze
 
       settings(
         :query, :name, :message, :escalation_message, :critical, :kennel_id, :type, :renotify_interval, :warning, :timeout_h, :evaluation_delay,
@@ -27,14 +27,14 @@ module Kennel
 
       defaults(
         message: -> { "\n\n@slack-#{project.slack}" },
-        escalation_message: -> { DEFAULT_ESCALATION_MESAGE.first },
+        escalation_message: -> { DEFAULT_ESCALATION_MESSAGE.first },
         renotify_interval: -> { MONITOR_OPTION_DEFAULTS.fetch(:renotify_interval) },
         warning: -> { nil },
-        ok: ->  { nil },
-        id: ->  { nil },
-        notify_no_data: -> { MONITOR_OPTION_DEFAULTS.fetch(:notify_no_data) },
+        ok: -> { nil },
+        id: -> { nil },
+        notify_no_data: -> { true },
         no_data_timeframe: -> { notify_no_data ? 60 : nil },
-        notify_audit: -> { MONITOR_OPTION_DEFAULTS.fetch(:notify_audit) },
+        notify_audit: -> { true },
         tags: -> { @project.tags },
         timeout_h: -> { MONITOR_OPTION_DEFAULTS.fetch(:timeout_h) },
         evaluation_delay: -> { MONITOR_OPTION_DEFAULTS.fetch(:evaluation_delay) },
@@ -142,7 +142,7 @@ module Kennel
 
         expected_options = expected[:options] || {}
         ignore_default(expected_options, options, MONITOR_OPTION_DEFAULTS)
-        if DEFAULT_ESCALATION_MESAGE.include?(options[:escalation_message])
+        if DEFAULT_ESCALATION_MESSAGE.include?(options[:escalation_message])
           options.delete(:escalation_message)
           expected_options.delete(:escalation_message)
         end

--- a/test/kennel/importer_test.rb
+++ b/test/kennel/importer_test.rb
@@ -98,6 +98,35 @@ describe Kennel::Importer do
       RUBY
     end
 
+    it "removes monitor default" do
+      response = { id: 123, name: "hello", options: { notify_audit: true } }
+      stub_datadog_request(:get, "monitor/123").to_return(body: response.to_json)
+      dash = importer.import("monitor", 123)
+      dash.must_equal <<~RUBY
+        Kennel::Models::Monitor.new(
+          self,
+          name: -> { "hello" },
+          id: -> { 123 },
+          kennel_id: -> { "hello" }
+        )
+      RUBY
+    end
+
+    it "keeps monitor values that are not the default" do
+      response = { id: 123, name: "hello", options: { notify_audit: false } }
+      stub_datadog_request(:get, "monitor/123").to_return(body: response.to_json)
+      dash = importer.import("monitor", 123)
+      dash.must_equal <<~RUBY
+        Kennel::Models::Monitor.new(
+          self,
+          name: -> { "hello" },
+          id: -> { 123 },
+          kennel_id: -> { "hello" },
+          notify_audit: -> { false }
+        )
+      RUBY
+    end
+
     it "can import a screen" do
       response = { id: 123, board_title: "hello" }
       stub_datadog_request(:get, "screen/123").to_return(body: response.to_json)

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -306,9 +306,17 @@ describe Kennel::Models::Monitor do
       Kennel::Models::Monitor.normalize({}, options: {})
     end
 
+    it "does not ignore notify_audit/notify_no_data since that would make import incorrect" do
+      actual = { options: { notify_audit: false, notify_no_data: false } }
+      expected = { options: { notify_audit: false, notify_no_data: false } }
+      Kennel::Models::Monitor.normalize(expected, actual)
+      expected.must_equal(options: { notify_audit: false, notify_no_data: false })
+      actual.must_equal(options: { notify_audit: false, notify_no_data: false })
+    end
+
     it "ignores defaults" do
-      actual = { options: { notify_audit: true } }
-      expected = { options: { notify_audit: true } }
+      actual = { options: { timeout_h: 0 } }
+      expected = { options: { timeout_h: 0 } }
       Kennel::Models::Monitor.normalize(expected, actual)
       expected.must_equal(options: {})
       actual.must_equal(options: {})


### PR DESCRIPTION
…is false for notify_audit/notify_no_data
