### PR TITLE
do not allow overriding existing methods via settings since it leads …

### DIFF
--- a/lib/kennel/models/base.rb
+++ b/lib/kennel/models/base.rb
@@ -14,6 +14,7 @@ module Kennel
         conditional_formats: [],
         aggregator: "avg"
       }.freeze
+      OVERRIDABLE_METHODS = [:name, :kennel_id].freeze
 
       class ValidationError < RuntimeError
       end
@@ -25,6 +26,11 @@ module Kennel
           duplicates = (@set & names)
           if duplicates.any?
             raise ArgumentError, "Settings #{duplicates.map(&:inspect).join(", ")} are already defined"
+          end
+
+          overrides = ((instance_methods - OVERRIDABLE_METHODS) & names)
+          if overrides.any?
+            raise ArgumentError, "Settings #{overrides.map(&:inspect).join(", ")} are already used as methods"
           end
 
           @set.concat names

--- a/test/kennel/models/base_test.rb
+++ b/test/kennel/models/base_test.rb
@@ -205,6 +205,11 @@ describe Kennel::Models::Base do
     it "does not override defined methods" do
       DefaultTestBase.new.name.must_equal "DefaultTestBase"
     end
+
+    it "does not allow overwriting base methods" do
+      e = assert_raises(ArgumentError) { DefaultTestBase.settings(:diff) }
+      e.message.must_equal "Settings :diff are already used as methods"
+    end
   end
 
   describe ".diff" do


### PR DESCRIPTION
…to funky errors

before:
```
ArgumentError: wrong number of arguments (given 1, expected 0)
```

after:
```
rake generate
Generating ... -rake aborted!
ArgumentError: Settings :url are already used as methods
lib/kennel/models/base.rb:27:in `settings'
projects/foo.rb:69:in `<class:Dashboard>'
```