### PR TITLE
add model for logging indexes

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -22,6 +22,7 @@ require "kennel/models/monitor"
 require "kennel/models/dash"
 require "kennel/models/dashboard"
 require "kennel/models/screen"
+require "kennel/models/logs_index"
 
 # settings
 require "kennel/models/project"

--- a/lib/kennel/models/logs_index.rb
+++ b/lib/kennel/models/logs_index.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Manage logging index configuration and ordering
+# https://docs.datadoghq.com/api/?lang=python#logs-indexes
+module Kennel
+  module Models
+    class LogsIndex < Base
+      @@index_order = []
+      class << self
+        def sorted
+          @@index_order.reject { |i| i.nil? }
+        end
+
+        def reset!
+          @@index_order = []
+        end
+      end
+
+      settings(:filter, :exclusion_filters, :order)
+      defaults(
+        filter: -> { {query: '*'} },
+        exclusion_filters: -> { [] },
+        order: -> { -1 }
+      )
+
+      def initialize(name, *args)
+        @name = name
+        super(*args)
+        @@index_order.insert(self.order, @name)
+      end
+
+      def as_json
+        @as_json ||= {
+          name: @name,
+          filter: filter,
+          exclusion_filters: exclusion_filters
+        }
+      end
+    end
+  end
+end

--- a/test/kennel/models/logs_index_test.rb
+++ b/test/kennel/models/logs_index_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require_relative "../../test_helper"
+
+SingleCov.covered!
+
+describe Kennel::Models::LogsIndex do
+  class TestLogIndex < Kennel::Models::LogsIndex
+  end
+  # generate readables diffs when things are not equal
+  def assert_json_equal(a, b)
+    JSON.pretty_generate(a).must_equal JSON.pretty_generate(b)
+  end
+
+  def index(options={})
+    Kennel::Models::LogsIndex.new(
+      'Kennel::Models::LogsIndex',
+      options
+    )
+  end
+
+  let(:expected_basic_json) do
+    {
+      name: 'Kennel::Models::LogsIndex',
+      filter: { query: '*' },
+      exclusion_filters: []
+    }
+  end
+
+  describe '#initialize' do
+    it 'sets defaults' do
+      index.exclusion_filters.must_equal []
+      index.filter[:query].must_equal '*'
+    end
+  end
+
+  describe '#as_json' do
+    it 'creates a basic json' do
+      assert_json_equal(
+        index.as_json,
+        expected_basic_json
+      )
+    end
+
+    it 'can set filter' do
+      new_index_filter = { query: 'service:foo' }
+      index(filter: -> { new_index_filter }).as_json.dig(:filter, :query).must_equal 'service:foo'
+    end
+
+    it 'can set exclusion filters' do
+      new_exclusion_filter = [{
+        name: 'exclusion_filter1',
+        is_enabled: true,
+        filter: {
+          query: 'service:bar',
+          sample_rate: 0.5
+        }
+      }]
+      index(exclusion_filters: -> { new_exclusion_filter }).exclusion_filters[0][:name].must_equal 'exclusion_filter1'
+    end
+  end
+
+  describe '.sorted' do
+    before do
+      Kennel::Models::LogsIndex.reset!
+    end
+    it 'tracks the index sort order' do
+      TestLogIndex.new('TestLogIndex1', order: -> { 100 })
+      TestLogIndex.new('TestLogIndex2')
+      TestLogIndex.new('TestLogIndex3', order: -> { 1 })
+      Kennel::Models::LogsIndex.sorted.must_equal ['TestLogIndex3', 'TestLogIndex1', 'TestLogIndex2']
+    end
+  end
+end


### PR DESCRIPTION
Datadog has recently released the public beta of the API for managing logging indexes.  It would be great to support this in Kennel.

https://docs.datadoghq.com/api/?lang=python#logs-indexes

= TODO
- [ ] Update generator / sync process to include index configuration and index order