### PR TITLE
support for auto-linking composite monitors

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -109,7 +109,7 @@ module Kennel
       end
 
       def resolve_linked_tracking_ids(id_map)
-        if as_json.fetch(:type) == "composite"
+        if as_json[:type] == "composite"
           begin
             as_json[:query].gsub!(/%\{(.*?)\}/) { id_map.fetch($1) }
           rescue KeyError => e

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -108,6 +108,16 @@ module Kennel
         @as_json = data
       end
 
+      def resolve_linked_tracking_ids(id_map)
+        if as_json.fetch(:type) == "composite"
+          begin
+            as_json[:query].gsub!(/%\{(.*?)\}/) { id_map.fetch($1) }
+          rescue KeyError => e
+            Kennel.err.puts("Unable to find #{e.key} in existing monitors (they need to be created first to link them)")
+          end
+        end
+      end
+
       def self.api_resource
         "monitor"
       end

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -228,7 +228,6 @@ describe Kennel::Models::Monitor do
   end
 
   describe "#resolve_linked_tracking_ids" do
-
     let(:mon) do
       monitor(query: -> { "%{#{project.kennel_id}:mon}" })
     end


### PR DESCRIPTION
This adds support for linking composite monitors by id. E.g.

`query: "%{proj:a} || %{proj:b} || %{proj:c}"`

is converted to the corresponding monitor ids if they exist:

`query: 123 || 124 || 125`