### PR TITLE
allow configuring renotify per team and fix renotify being deleted is…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -154,6 +154,12 @@ end
 Some validations might be too strict for your usecase or just wrong, please [open an issue](https://github.com/grosser/kennel/issues) and
 to unblock use the `validate: -> { false }` option.
 
+### Monitor re-notification
+
+Monitors inherit the re-notification setting from their `project.team`.
+Set this to for example `renotify_interval: -> { 120 }` minutes,
+to make alerts not get ignored by popping back up if they are still alerting.
+
 ### Linking with kennel_ids
 
 To link to existing monitors via their kennel_id

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -15,7 +15,7 @@ module Kennel
         evaluation_delay: nil,
         new_host_delay: 300,
         timeout_h: 0,
-        renotify_interval: 120,
+        renotify_interval: 0,
         no_data_timeframe: nil # this works out ok since if notify_no_data is on, it would never be nil
       }.freeze
       DEFAULT_ESCALATION_MESSAGE = ["", nil].freeze
@@ -29,7 +29,7 @@ module Kennel
       defaults(
         message: -> { "\n\n@slack-#{project.slack}" },
         escalation_message: -> { DEFAULT_ESCALATION_MESSAGE.first },
-        renotify_interval: -> { MONITOR_OPTION_DEFAULTS.fetch(:renotify_interval) },
+        renotify_interval: -> { project.team.renotify_interval },
         warning: -> { nil },
         ok: -> { nil },
         id: -> { nil },

--- a/lib/kennel/models/team.rb
+++ b/lib/kennel/models/team.rb
@@ -2,9 +2,10 @@
 module Kennel
   module Models
     class Team < Base
-      settings :slack, :email, :tags, :kennel_id
+      settings :slack, :email, :tags, :renotify_interval, :kennel_id
       defaults(
-        tags: -> { ["team:#{kennel_id.sub(/^teams_/, "")}"] }
+        tags: -> { ["team:#{kennel_id.sub(/^teams_/, "")}"] },
+        renotify_interval: -> { 0 }
       )
 
       def initialize(*)

--- a/template/Readme.md
+++ b/template/Readme.md
@@ -136,12 +136,18 @@ end
 Some validations might be too strict for your usecase or just wrong, please [open an issue](https://github.com/grosser/kennel/issues) and
 to unblock use the `validate: -> { false }` option.
 
+### Monitor re-notification
+
+Monitors inherit the re-notification setting from their projects team.
+By default this is `renotify_interval: -> { 120 }` minutes, which will make alerts not get ignored by popping back up.
+
 ### Linking with kennel_ids
 
 To link to existing monitors via their kennel_id
 
  - Screens `uptime` widgets can use `monitor: {id: "foo:bar"}`
  - Screens `alert_graph` widgets can use `alert_id: "foo:bar"`
+ - Monitors `composite` can use `query: -> { "%{foo:bar} || %{foo:baz}" }`
 
 ### Debugging changes locally
 

--- a/test/kennel/importer_test.rb
+++ b/test/kennel/importer_test.rb
@@ -191,7 +191,8 @@ describe Kennel::Importer do
           id: -> { 123 },
           kennel_id: -> { "hello" },
           critical: -> { 25.0 },
-          notify_no_data: -> { false }
+          notify_no_data: -> { false },
+          renotify_interval: -> { 120 }
         )
       RUBY
     end

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -43,7 +43,7 @@ describe Kennel::Models::Monitor do
         escalation_message: nil,
         evaluation_delay: nil,
         locked: false,
-        renotify_interval: 120,
+        renotify_interval: 0,
         thresholds: { critical: 123.0 }
       }
     }
@@ -95,6 +95,10 @@ describe Kennel::Models::Monitor do
 
     it "sets 0 when re-notify is disabled" do
       monitor(renotify_interval: -> { false }).as_json[:options][:renotify_interval].must_equal 0
+    end
+
+    it "can set re-notify interval" do
+      monitor(renotify_interval: -> { 60 }).as_json[:options][:renotify_interval].must_equal 60
     end
 
     it "can set require_full_window" do

--- a/test/kennel/models/team_test.rb
+++ b/test/kennel/models/team_test.rb
@@ -19,4 +19,10 @@ describe Kennel::Models::Team do
       assert_raises(Kennel::Models::Base::ValidationError) { Teams::MyTeam.new(slack: -> { "#foo" }) }
     end
   end
+
+  describe "#renotify_interval" do
+    it "is set to datadogs default" do
+      Teams::MyTeam.new.renotify_interval.must_equal 0
+    end
+  end
 end


### PR DESCRIPTION
…sues

previously did not submit the value, so it turned it off ... resetting to datadogs default to avoid future surprises