### PR TITLE
Add support for scoping alerts

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -175,9 +175,10 @@ To link to existing monitors via their kennel_id
  - figure out project name by converting the class name to snake-case
  - run `PROJECT=foo bundle exec rake kennel:update_datadog` to test changes for a single project
 
-### Listing un-muted alerts
+### Listing unmuted alerts
 
-Run `rake kennel:alerts TAG=service:my-service` to see all un-muted alerts for a given datadog monitor tag.
+Run `rake kennel:alerts TAG=service:my-service SCOPE=scope` to see all un-muted alerts for a given datadog monitor tag.
+Scope is optional and can be omitted.
 
 ### Validating mentions work
 

--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -77,7 +77,8 @@ namespace :kennel do
   desc "show unmuted alerts filtered by TAG, for example TAG=team:foo"
   task alerts: :environment do
     tag = ENV["TAG"] || abort("Call with TAG=foo:bar")
-    Kennel::UnmutedAlerts.print(Kennel.send(:api), tag)
+    scope = ENV["SCOPE"]
+    Kennel::UnmutedAlerts.print(Kennel.send(:api), tag, scope)
   end
 
   desc "show monitors with no data by TAG, for example TAG=team:foo"

--- a/lib/kennel/unmuted_alerts.rb
+++ b/lib/kennel/unmuted_alerts.rb
@@ -11,12 +11,16 @@ module Kennel
     }.freeze
 
     class << self
-      def print(api, tag)
+      def print(api, tag, scope)
         monitors = filtered_monitors(api, tag)
         if monitors.empty?
           Kennel.out.puts "No unmuted alerts found"
         else
           monitors.each do |m|
+            if scope
+              m[:state][:groups].select! { |g| g[:name].include?(scope) }
+            end
+            next if m[:state][:groups].empty?
             Kennel.out.puts m[:name]
             Kennel.out.puts Utils.path_to_url("/monitors/#{m[:id]}")
             m[:state][:groups].each do |g|
@@ -44,7 +48,7 @@ module Kennel
       end
 
       def filtered_monitors(api, tag)
-        # Download all monitors with given tag
+        # Download all monitors with given tag and scope
         monitors = Progress.progress("Downloading") do
           api.list("monitor", monitor_tags: tag, group_states: "all", with_downtimes: "true")
         end


### PR DESCRIPTION
To allow further scope alerts.

I.e. it allows to show only alerts from production (assuming monitors using it in grouping)