### PR TITLE
adds dashboard_list_id to defaults for dashboard

### DIFF
--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -15,13 +15,14 @@ module Kennel
       }.freeze
       SUPPORTED_DEFINITION_OPTIONS = [:events, :markers, :precision].freeze
 
-      settings :id, :title, :description, :definitions, :widgets, :kennel_id, :layout_type
+      settings :id, :title, :description, :definitions, :widgets, :kennel_id, :layout_type, :dashboard_list_id
 
       defaults(
         description: -> { "" },
         definitions: -> { [] },
         widgets: -> { [] },
-        id: -> { nil }
+        id: -> { nil },
+        dashboard_list_id: -> { "" }
       )
 
       class << self
@@ -76,6 +77,8 @@ module Kennel
         }
 
         @json[:id] = id if id
+
+        @json[:dashboard_list_id] = dashboard_list_id unless dashboard_list_id == ""
 
         validate_json(@json) if validate
 

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -62,6 +62,10 @@ describe Kennel::Models::Dashboard do
       dashboard(id: -> { "abc" }).as_json.must_equal expected_json.merge(id: "abc")
     end
 
+    it "adds dashboard_list_id when given" do
+      dashboard(dashboard_list_id: -> { "1337" }).as_json.must_equal expected_json.merge(dashboard_list_id: "1337")
+    end
+
     it "can resolve q from metadata" do
       expected_json_with_requests[:widgets][0][:definition][:requests][0][:metadata] = [{ expression: "foo" }]
       dashboard(


### PR DESCRIPTION
Adds the possibility to specify `dashboard_list_id` so people can (if they want) add a rake task to push dashboards to dashboard lists in their kennel setup.

This is the shortcut solution for obtaining a managable state of dashboard lists, I am perfectly fine investing my spare-time into adding the dashboard model and properly integrating into the `syncer`.

