### PR TITLE
validate SLO warning/critical values

### DIFF
--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -23,7 +23,10 @@ module Kennel
 
       def initialize(*)
         super
-        raise ValidationError, "Threshold warning must be greater-than critical value" if thresholds.any? { |t| t[:warning].to_f <= t[:critical].to_f }
+
+        raise ValidationError, "Threshold warning must be greater-than critical value" if thresholds.any? do |t|
+          t.key?(:warning) && !t[:warning].nil? && t[:warning].to_f <= t[:critical].to_f
+        end
       end
 
       def as_json

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -19,6 +19,11 @@ module Kennel
         monitor_ids: -> { DEFAULTS.fetch(:monitor_ids) }
       )
 
+      def initialize(project, *args)
+        super(project, *args)
+        raise ValidationError, 'Threshold warning must be less-than critical value' if thresholds.each { |t| t[:warning].to_f < t[:critical].to_f }
+      end
+
       def as_json
         return @as_json if @as_json
         data = {

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -21,9 +21,9 @@ module Kennel
         thresholds: -> { DEFAULTS.fetch(:thresholds) }
       )
 
-      def initialize(project, *args)
-        super(project, *args)
-        raise ValidationError, "Threshold warning must be greater-than critical value" if thresholds.any? { |t| t[:warning].to_f < t[:critical].to_f }
+      def initialize(*)
+        super
+        raise ValidationError, "Threshold warning must be greater-than critical value" if thresholds.any? { |t| t[:warning].to_f <= t[:critical].to_f }
       end
 
       def as_json

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -6,7 +6,8 @@ module Kennel
       DEFAULTS = {
         description: nil,
         query: nil,
-        monitor_ids: []
+        monitor_ids: [],
+        thresholds: []
       }.freeze
 
       settings :type, :description, :thresholds, :query, :tags, :monitor_ids, :monitor_tags, :name
@@ -16,12 +17,13 @@ module Kennel
         tags: -> { @project.tags },
         query: -> { DEFAULTS.fetch(:query) },
         description: -> { DEFAULTS.fetch(:description) },
-        monitor_ids: -> { DEFAULTS.fetch(:monitor_ids) }
+        monitor_ids: -> { DEFAULTS.fetch(:monitor_ids) },
+        thresholds: -> { DEFAULTS.fetch(:thresholds) }
       )
 
       def initialize(project, *args)
         super(project, *args)
-        raise ValidationError, 'Threshold warning must be less-than critical value' if thresholds.each { |t| t[:warning].to_f < t[:critical].to_f }
+        raise ValidationError, "Threshold warning must be greater-than critical value" if thresholds.any? { |t| t[:warning].to_f < t[:critical].to_f }
       end
 
       def as_json

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -23,9 +23,8 @@ module Kennel
 
       def initialize(*)
         super
-
-        raise ValidationError, "Threshold warning must be greater-than critical value" if thresholds.any? do |t|
-          t.key?(:warning) && !t[:warning].nil? && t[:warning].to_f <= t[:critical].to_f
+        if thresholds.any? { |t| t[:warning] && t[:warning].to_f <= t[:critical].to_f }
+          raise ValidationError, "Threshold warning must be greater-than critical value"
         end
       end
 

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -49,6 +49,9 @@ describe Kennel::Models::Slo do
       assert_raises Kennel::Models::Record::ValidationError do
         Kennel::Models::Slo.new(project, thresholds: -> { [{ warning: 0, critical: 99 }] })
       end
+      assert_raises Kennel::Models::Record::ValidationError do
+        Kennel::Models::Slo.new(project, thresholds: -> { [{ warning: 99, critical: 99 }] })
+      end
     end
   end
 

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -44,6 +44,12 @@ describe Kennel::Models::Slo do
     it "stores options" do
       TestSlo.new(project, name: -> { "XXX" }).name.must_equal "XXX"
     end
+
+    it "validates thresholds" do
+      assert_raises Kennel::Models::Record::ValidationError do
+        Kennel::Models::Slo.new(project, thresholds: -> { [{ warning: 0, critical: 99 }] })
+      end
+    end
   end
 
   describe "#as_json" do

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -56,7 +56,7 @@ describe Kennel::Models::Slo do
         end
       end
 
-      it "is invalid warning != critical" do
+      it "is invalid if warning == critical" do
         assert_raises Kennel::Models::Record::ValidationError do
           Kennel::Models::Slo.new(project, thresholds: -> { [{ warning: 99, critical: 99 }] })
         end

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -45,12 +45,21 @@ describe Kennel::Models::Slo do
       TestSlo.new(project, name: -> { "XXX" }).name.must_equal "XXX"
     end
 
-    it "validates thresholds" do
-      assert_raises Kennel::Models::Record::ValidationError do
-        Kennel::Models::Slo.new(project, thresholds: -> { [{ warning: 0, critical: 99 }] })
+    describe "validates threshold" do
+      it "is valid when warning not set" do
+        Kennel::Models::Slo.new(project, thresholds: -> { [{ critical: 99 }] })
       end
-      assert_raises Kennel::Models::Record::ValidationError do
-        Kennel::Models::Slo.new(project, thresholds: -> { [{ warning: 99, critical: 99 }] })
+
+      it "is invalid if warning > critical" do
+        assert_raises Kennel::Models::Record::ValidationError do
+          Kennel::Models::Slo.new(project, thresholds: -> { [{ warning: 0, critical: 99 }] })
+        end
+      end
+
+      it "is invalid warning != critical" do
+        assert_raises Kennel::Models::Record::ValidationError do
+          Kennel::Models::Slo.new(project, thresholds: -> { [{ warning: 99, critical: 99 }] })
+        end
       end
     end
   end


### PR DESCRIPTION
Add validation of SLO thresholds when the record is created.  It would be cool to have a set of `rules` associated with each model type, and have the validation handled in the `initialize` method in the `Record` class.

Example error from the Datadog API:
```
response:                                                                                                              
{"errors": ["warning must be greater than slo value"]}                                                                 
```