### PR TITLE
Allow 2d and 1w intervals for anomaly monitors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 template/Gemfile.lock
+tmp/

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -5,7 +5,8 @@ module Kennel
       include OptionalValidations
 
       RENOTIFY_INTERVALS = [0, 10, 20, 30, 40, 50, 60, 90, 120, 180, 240, 300, 360, 720, 1440].freeze # minutes
-      QUERY_INTERVALS = ["1m", "5m", "10m", "15m", "30m", "1h", "2h", "4h", "1d"].freeze
+      # 2d and 1w are valid timeframes for anomaly monitors
+      QUERY_INTERVALS = ["1m", "5m", "10m", "15m", "30m", "1h", "2h", "4h", "1d", "2d", "1w"].freeze
       OPTIONAL_SERVICE_CHECK_THRESHOLDS = [:ok, :warning].freeze
       READONLY_ATTRIBUTES = superclass::READONLY_ATTRIBUTES + [
         :multi, :matching_downtimes, :overall_state_modified, :overall_state, :restricted_roles

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -130,7 +130,7 @@ describe Kennel::Models::Monitor do
 
     it "fails when using invalid interval for query alert type" do
       e = assert_raises(RuntimeError) { monitor(critical: -> { 234.1 }, query: -> { "avg(last_20m).count() < #{critical}" }).as_json }
-      e.message.must_equal "test_project:m1 query interval was 20m, but must be one of 1m, 5m, 10m, 15m, 30m, 1h, 2h, 4h, 1d"
+      e.message.must_equal "test_project:m1 query interval was 20m, but must be one of 1m, 5m, 10m, 15m, 30m, 1h, 2h, 4h, 1d, 2d, 1w"
     end
 
     it "allows next_x interval for query alert type" do


### PR DESCRIPTION
Datadog's anomaly monitor UI implicitly creates queries like this:

```
avg(last_1w):anomalies(sum:foo.domain_event{env:production} by {event}.as_count(), 'agile', 5, direction='below', alert_window='last_1d', interval=3600, count_default_zero='true', seasonality='weekly') >= 1
```

The value in the first field is not present in the UI, but scales ahead of the "alert window" you define.

Using the above query definition prior to this change raises this exception:

```
Kennel::ValidationError: foo query interval was 1w, but must be one of 1m, 5m, 10m, 15m, 30m, 1h, 2h, 4h, 1d
```

I've confirmed this change allows the above query to generate successfully in the downstream monitor repository.