### PR TITLE
Add support for template_variable_presets

### DIFF
--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -16,12 +16,13 @@ module Kennel
       TIMESERIES_DEFAULTS = { show_legend: false, legend_size: "0" }.freeze
       SUPPORTED_DEFINITION_OPTIONS = [:events, :markers, :precision].freeze
 
-      settings :title, :description, :definitions, :widgets, :layout_type
+      settings :title, :description, :definitions, :widgets, :layout_type, :template_variable_presets
 
       defaults(
         description: -> { "" },
         definitions: -> { [] },
         widgets: -> { [] },
+        template_variable_presets: -> { [] },
         id: -> { nil }
       )
 
@@ -102,6 +103,7 @@ module Kennel
           title: "#{title}#{LOCK}",
           description: description,
           template_variables: render_template_variables,
+          template_variable_presets: template_variable_presets,
           widgets: all_widgets
         }
 
@@ -167,6 +169,10 @@ module Kennel
         super
 
         validate_template_variables data, :widgets
+
+        # Avoid diff from datadog presets sorting.
+        presets = data[:template_variable_presets]
+        invalid! "template_variable_presets must be sorted by name" if presets != presets.sort_by { |p| p[:name] }
       end
 
       def render_definitions

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -18,6 +18,7 @@ describe Kennel::Models::Dashboard do
       layout_type: "ordered",
       description: "",
       template_variables: [],
+      template_variable_presets: [],
       widgets: []
     }
   end
@@ -56,6 +57,16 @@ describe Kennel::Models::Dashboard do
 
     it "can ignore validations" do
       dashboard(widgets: -> { [{ definition: { "foo" => 1 } }] }, validate: -> { false }).as_json
+    end
+
+    it "complains when datadog would created a diff by sorting template_variable_presets" do
+      assert_raises Kennel::ValidationError do
+        dashboard(template_variable_presets: -> { [{ name: "B" }, { name: "A" }] }).as_json
+      end
+    end
+
+    it "doesn't complain on sorted template_variable_presets" do
+      dashboard(template_variable_presets: -> { [{ name: "A" }, { name: "B" }] }).as_json
     end
 
     it "adds ID when given" do


### PR DESCRIPTION
Add support for `template_variable_presets`.
Allows to keep saved views with the dashboards.