### PR TITLE
Validate 'service check' style queries

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -202,7 +202,7 @@ module Kennel
           # verify is_match uses available variables
           message = data.fetch(:message)
           used = message.scan(/{{\s*#is_match\s*"([a-zA-Z\d_.-]+).name"/).flatten.uniq
-          allowed = data.fetch(:query)[/by\s*{([^\}]+)}/, 1].to_s.split(/\s*,\s*/)
+          allowed = data.fetch(:query)[/by\s*[\({]([^\}\)]+)[}\)]/, 1].to_s.gsub(/["']/, "").split(/\s*,\s*/)
           unsupported = used - allowed
           if unsupported.any?
             invalid! "is_match used with #{unsupported}, but metric is only grouped by #{allowed}"


### PR DESCRIPTION
`service check` monitors allow a group by syntax like:

```
"\"zendesk.nginx_config.valid\".over(\"hostgroup:exodus\").by(\"environment\",\"host\").last(1).pct_by_status()",
```

This updates the regex of allowed group by to match `(` as well as `{` and sanitises the matches of quotation marks.

Reference: https://zendesk.datadoghq.com/monitors/10116539?q=host%3Aexodus1.pod999.use1.zdsystest.com%2Crunit_service%3Azendesk_exodus_runner&from_ts=1593064799000&to_ts=1593068459000&eval_ts=1593068459000