### PR TITLE
Make slo regex more forgiving on different url format

### DIFF
--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -63,7 +63,7 @@ module Kennel
       end
 
       def self.parse_url(url)
-        url[/\/slo\?slo_id=([a-z\d]+)/, 1]
+        url[/\/slo\?.*slo_id=([a-z\d]+)/, 1]
       end
 
       def resolve_linked_tracking_ids!(id_map, **args)

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -142,6 +142,11 @@ describe Kennel::Models::Slo do
       Kennel::Models::Slo.parse_url(url).must_equal "foo"
     end
 
+    it "parses when other query strings are present" do
+      url = "https://app.datadoghq.com/slo?query=\"bar\"&slo_id=foo&timeframe=7d&tab=status_and_history"
+      Kennel::Models::Slo.parse_url(url).must_equal "foo"
+    end
+
     it "fails to parse other" do
       url = "https://app.datadoghq.com/dashboard/bet-foo-bar?from_ts=1585064592575&to_ts=1585068192575&live=true"
       Kennel::Models::Slo.parse_url(url).must_be_nil


### PR DESCRIPTION
### Description

It's possible for the SLO URL in Datadog to contain other query strings when other filtering criteria are applied (ex: `https://foo.datadoghq.com/slo?query="bar"&slo_id=<slo_id>`). 
Currently the regex for SLO assumes that the `slo_id` is the first query string param.

- Allow characters to appear before the `slo_id` query param.