### PR TITLE
resolve dependencies in a loop to support composite and mon->slo->mon

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,3 +99,6 @@ Layout/EmptyLineAfterGuardClause:
 
 Style/FormatStringToken:
   EnforcedStyle: unannotated
+
+Style/EmptyElse:
+  Enabled: false

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -140,16 +140,16 @@ module Kennel
           when "uptime"
             if ids = definition[:monitor_ids]
               definition[:monitor_ids] = ids.map do |id|
-                tracking_id?(id) ? resolve_link(id, :monitor, id_map, **args) : id
+                tracking_id?(id) ? (resolve_link(id, :monitor, id_map, **args) || id) : id
               end
             end
           when "alert_graph"
             if (id = definition[:alert_id]) && tracking_id?(id)
-              definition[:alert_id] = resolve_link(id, :monitor, id_map, **args).to_s
+              definition[:alert_id] = (resolve_link(id, :monitor, id_map, **args) || id).to_s
             end
           when "slo"
             if (id = definition[:slo_id]) && tracking_id?(id)
-              definition[:slo_id] = resolve_link(id, :slo, id_map, **args).to_s
+              definition[:slo_id] = (resolve_link(id, :slo, id_map, **args) || id).to_s
             end
           end
         end

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -116,7 +116,7 @@ module Kennel
         when "composite", "slo alert"
           type = (as_json[:type] == "composite" ? :monitor : :slo)
           as_json[:query] = as_json[:query].gsub(/%{(.*?)}/) do
-            resolve_link($1, type, id_map, **args)
+            resolve_link($1, type, id_map, **args) || $&
           end
         end
       end

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -65,19 +65,18 @@ module Kennel
 
       private
 
-      def resolve_link(id, type, id_map, force:)
-        value = id_map[id]
-        if value == :new
+      def resolve_link(tracking_id, type, id_map, force:)
+        id = id_map[tracking_id]
+        if id == :new
           if force
-            # TODO: remove the need for this by sorting monitors by missing resolutions
-            invalid! "#{id} needs to already exist, try again"
+            invalid! "#{type} #{tracking_id} was referenced but is also created by the current run.\nIt could not be created because of a circular dependency, try creating only some of the resources"
           else
-            id # will be re-resolved by syncer after the linked object was created
+            nil # will be re-resolved after the linked object was created
           end
-        elsif value
-          value
+        elsif id
+          id
         else
-          invalid! "Unable to find #{type} #{id} (does not exist and is not being created by the current run)"
+          invalid! "Unable to find #{type} #{tracking_id} (does not exist and is not being created by the current run)"
         end
       end
 

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -69,7 +69,7 @@ module Kennel
       def resolve_linked_tracking_ids!(id_map, **args)
         return unless as_json[:monitor_ids] # ignore_default can remove it
         as_json[:monitor_ids] = as_json[:monitor_ids].map do |id|
-          id.is_a?(String) ? resolve_link(id, :monitor, id_map, **args) : id
+          id.is_a?(String) ? (resolve_link(id, :monitor, id_map, **args) || id) : id
         end
       end
 

--- a/test/kennel/api_test.rb
+++ b/test/kennel/api_test.rb
@@ -171,7 +171,7 @@ describe Kennel::Api do
 
     it "retries on timeout" do
       request = stub_request(:get, "monitor/1234").to_timeout
-      assert_raises Faraday::ConnectionFailed do
+      assert_raises Faraday::TimeoutError do
         api.show("monitor", 1234).must_equal foo: "bar"
       end
       assert_requested request, times: 3

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -156,7 +156,7 @@ describe Kennel::Models::Dashboard do
         e = assert_raises Kennel::ValidationError do
           resolve({ "missing:the_id" => :new }, force: true)
         end
-        e.message.must_include "missing:the_id needs to already exist"
+        e.message.must_include "circular dependency"
       end
     end
 

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -302,6 +302,11 @@ describe Kennel::Models::Monitor do
         e.message.must_include "test_project:m1 Unable to find monitor foo:mon_a"
       end
 
+      it "does not fail when unable to try to resolve" do
+        mon.resolve_linked_tracking_ids!({ "foo:mon_a" => :new, "bar:mon_b" => :new }, force: false)
+        mon.as_json[:query].must_equal "%{foo:mon_a} || !%{bar:mon_b}", "query not modified"
+      end
+
       it "resolves correctly with a matching monitor" do
         mon.resolve_linked_tracking_ids!({ "foo:mon_x" => 3, "foo:mon_a" => 1, "bar:mon_b" => 2 }, force: false)
         mon.as_json[:query].must_equal("1 || !2")

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -36,22 +36,22 @@ describe Kennel::Models::Record do
   describe "#resolve_link" do
     let(:base) { Kennel::Models::Monitor.new(TestProject.new, kennel_id: -> { "test" }) }
 
-    it "resolves" do
+    it "resolves existing" do
       base.send(:resolve_link, "foo", :monitor, { "foo" => 2 }, force: false).must_equal 2
     end
 
-    it "warns when new but not required" do
-      base.send(:resolve_link, "foo", :monitor, { "foo" => :new }, force: false).must_equal "foo"
+    it "warns when trying to resolve" do
+      base.send(:resolve_link, "foo", :monitor, { "foo" => :new }, force: false).must_be_nil
     end
 
-    it "fails when new but required" do
+    it "fails when forcing resolve because of a circular dependency" do
       e = assert_raises Kennel::ValidationError do
         base.send(:resolve_link, "foo", :monitor, { "foo" => :new }, force: true)
       end
-      e.message.must_include "needs to already exist, try again"
+      e.message.must_include "circular dependency"
     end
 
-    it "fails when missing" do
+    it "fails when trying to resolve but it is unresolvable" do
       e = assert_raises Kennel::ValidationError do
         base.send(:resolve_link, "foo", :monitor, { "bar" => 1 }, force: false)
       end


### PR DESCRIPTION
Test case:
```
        Kennel::Models::Monitor.new(
          self,
          name: -> { "comp1" },
          kennel_id: -> { "comp1" },
          type: -> { "composite" },
          query: -> { "%{kube_stats:comp2} && %{kube_stats:comp3}" }
        ),
        Kennel::Models::Monitor.new(
          self,
          name: -> { "comp2" },
          kennel_id: -> { "comp2" },
          type: -> { "composite" },
          query: -> { "%{kube_stats:comp3} && %{kube_stats:comp4}" }
        ),
        Kennel::Models::Monitor.new(
          self,
          name: -> { "comp3" },
          kennel_id: -> { "comp3" },
          type: -> { "query alert" },
          query: -> { "sum(last_30m):avg:foo{*} by {kube_cluster}.as_count() > #{critical}" },
          critical: -> { 100 }
        ),
        Kennel::Models::Monitor.new(
          self,
          name: -> { "comp4" },
          kennel_id: -> { "comp4" },
          type: -> { "query alert" },
          query: -> { "sum(last_30m):avg:foo{*} by {kube_cluster}.as_count() > #{critical}" },
          critical: -> { 100 }
        ),
```

result when successful (with debug output):
```
Plan:
Create monitor kube_stats:comp1
Create monitor kube_stats:comp2
Create monitor kube_stats:comp3
Create monitor kube_stats:comp4
Execute Plan ? -  press 'y' to continue: y
CHECKING kube_stats:comp1
CHECKING kube_stats:comp2
CHECKING kube_stats:comp3
GO
Created monitor kube_stats:comp3 https://zendesk.datadoghq.com/monitors#28449762/edit
CHECKING kube_stats:comp4
GO
Created monitor kube_stats:comp4 https://zendesk.datadoghq.com/monitors#28449763/edit
CHECKING kube_stats:comp1
CHECKING kube_stats:comp2
GO
Created monitor kube_stats:comp2 https://zendesk.datadoghq.com/monitors#28449764/edit
CHECKING kube_stats:comp1
GO
Created monitor kube_stats:comp1 https://zendesk.datadoghq.com/monitors#28449765/edit
```

result when failing (added a unresolvable loop):
```
Diffing ... 0.37s
Plan:
Create monitor kube_stats:comp1
Create monitor kube_stats:comp2
Create monitor kube_stats:comp3
Create monitor kube_stats:comp4
Execute Plan ? -  press 'y' to continue: y
Created monitor kube_stats:comp3 https://zendesk.datadoghq.com/monitors#28449827/edit
Created monitor kube_stats:comp4 https://zendesk.datadoghq.com/monitors#28449828/edit
rake aborted!
Kennel::ValidationError: kube_stats:comp1 Unable to find monitor kube_stats:comp2 (does not exist and is not being created by the current run)
```