### PR TITLE
Remove query alert interval verification

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -5,8 +5,6 @@ module Kennel
       include OptionalValidations
 
       RENOTIFY_INTERVALS = [0, 10, 20, 30, 40, 50, 60, 90, 120, 180, 240, 300, 360, 720, 1440].freeze # minutes
-      # 2d and 1w are valid timeframes for anomaly monitors
-      QUERY_INTERVALS = ["1m", "5m", "10m", "15m", "30m", "1h", "2h", "4h", "1d", "2d", "1w"].freeze
       OPTIONAL_SERVICE_CHECK_THRESHOLDS = [:ok, :warning].freeze
       READONLY_ATTRIBUTES = superclass::READONLY_ATTRIBUTES + [
         :multi, :matching_downtimes, :overall_state_modified, :overall_state, :restricted_roles
@@ -200,14 +198,6 @@ module Kennel
         # verify renotify interval is valid
         unless RENOTIFY_INTERVALS.include? data.dig(:options, :renotify_interval)
           invalid! "renotify_interval must be one of #{RENOTIFY_INTERVALS.join(", ")}"
-        end
-
-        if type == "query alert"
-          # verify interval is valid
-          interval = data.fetch(:query)[/\(last_(\S+?)\)/, 1]
-          if interval && !QUERY_INTERVALS.include?(interval)
-            invalid! "query interval was #{interval}, but must be one of #{QUERY_INTERVALS.join(", ")}"
-          end
         end
 
         if ["query alert", "service check"].include?(type) # TODO: most likely more types need this

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -129,11 +129,6 @@ describe Kennel::Models::Monitor do
       json.dig(:options, :thresholds, :warning).must_equal 1
     end
 
-    it "fails when using invalid interval for query alert type" do
-      e = assert_raises(RuntimeError) { monitor(critical: -> { 234.1 }, query: -> { "avg(last_20m).count() < #{critical}" }).as_json }
-      e.message.must_equal "test_project:m1 query interval was 20m, but must be one of 1m, 5m, 10m, 15m, 30m, 1h, 2h, 4h, 1d, 2d, 1w"
-    end
-
     it "allows next_x interval for query alert type" do
       monitor(critical: -> { 234.1 }, query: -> { "avg(next_20m).count() < #{critical}" }).as_json
     end


### PR DESCRIPTION
Aside from the normal interval such as 5 minutes, 15 minutes, 1 hour, etc. query interval selection now includes an option to set a custom value between 1 minute to 48 hours. This means something like this should be valid:

`max(last_91m):min:datadog.agent.running{hostgroup:jumpbox} by {host,pod}.fill(zero) < 1`

https://docs.datadoghq.com/monitors/monitor_types/metric/?tab=threshold