### PR TITLE
Update url parsing

### DIFF
--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -63,7 +63,7 @@ module Kennel
       end
 
       def self.parse_url(url)
-        url[/\/slo\?.*slo_id=([a-z\d]+)/, 1]
+        url[/\/slo(\?.*slo_id=|\/edit\/)([a-z\d]{10,})/, 2]
       end
 
       def resolve_linked_tracking_ids!(id_map, **args)

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -144,13 +144,18 @@ describe Kennel::Models::Slo do
 
   describe ".parse_url" do
     it "parses" do
-      url = "https://app.datadoghq.com/slo?slo_id=foo&timeframe=7d&tab=status_and_history"
-      Kennel::Models::Slo.parse_url(url).must_equal "foo"
+      url = "https://app.datadoghq.com/slo?slo_id=123456789123&timeframe=7d&tab=status_and_history"
+      Kennel::Models::Slo.parse_url(url).must_equal "123456789123"
     end
 
     it "parses when other query strings are present" do
-      url = "https://app.datadoghq.com/slo?query=\"bar\"&slo_id=foo&timeframe=7d&tab=status_and_history"
-      Kennel::Models::Slo.parse_url(url).must_equal "foo"
+      url = "https://app.datadoghq.com/slo?query=\"bar\"&slo_id=123456789123&timeframe=7d&tab=status_and_history"
+      Kennel::Models::Slo.parse_url(url).must_equal "123456789123"
+    end
+
+    it "parses url with id" do
+      url = "https://app.datadoghq.com/slo/edit/123456789123"
+      Kennel::Models::Slo.parse_url(url).must_equal "123456789123"
     end
 
     it "fails to parse other" do


### PR DESCRIPTION
Updating the SLO's URL parsing to accommodate URLs with `slo/some_slo_id` and `slo/edit/some_slo_id`, and
ensuring that the `id` will be 10+ characters.