### PR TITLE
Add LogMetric record and APIs

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -21,6 +21,7 @@ require "kennel/models/record"
 
 # records
 require "kennel/models/dashboard"
+require "kennel/models/log_metric"
 require "kennel/models/monitor"
 require "kennel/models/slo"
 

--- a/lib/kennel/models/log_metric.rb
+++ b/lib/kennel/models/log_metric.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Kennel
+  module Models
+    class LogMetric < Record
+      VIRTUAL_ID = true
+
+      settings(:metric, :query, :group_by, :aggregation_type, :aggregation_path)
+
+      defaults(
+        group_by: -> { [] },
+        aggregation_type: -> { "count" },
+        aggregation_path: -> { nil }
+      )
+
+      # log metrics don't have any free-text description/message, so we stuff the tracking id into the query
+      TRACKING_FIELD = [:attributes, :filter, :query].freeze
+      TRACKING_REGEX = /-managed_by_kennel:"(\S+)"/
+
+      class << self
+        def api_resource
+          "logs/config/metrics"
+        end
+
+        def parse_tracking_id(a)
+          a.dig(*TRACKING_FIELD).to_s[TRACKING_REGEX, 1]
+        end
+
+        def remove_tracking_id(a)
+          value = a.dig(*TRACKING_FIELD)
+          value.sub!(TRACKING_REGEX, "") ||
+            raise("did not find tracking id in #{value}")
+        end
+
+        def url(id)
+          Utils.path_to_url "/logs/pipelines/generate-metrics/#{id}"
+        end
+      end
+
+      def id
+        metric
+      end
+
+      def as_json
+        return @as_json if @as_json
+        data = {
+          id: metric,
+          type: 'logs_metrics',
+          attributes: {
+            filter: {
+              query: query.dup # unfreeze
+            },
+            group_by: group_by,
+            compute: {
+              aggregation_type: aggregation_type
+            }
+          }
+        }
+
+        if aggregation_type == "distribution"
+          data[:attributes][:compute][:path] = aggregation_path
+        end
+
+        @as_json = data
+      end
+
+      def add_tracking_id
+        json = as_json
+        if self.class.parse_tracking_id(json)
+          invalid! "remove \"-managed_by_kennel\" portion from query to copy a resource"
+        end
+        json.dig(*TRACKING_FIELD).replace(json.dig(*TRACKING_FIELD) + " -managed_by_kennel:\"#{tracking_id}\"")
+      end
+    end
+  end
+end

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -153,7 +153,7 @@ module Kennel
       @expected.each do |e|
         next unless id = e.id
         resource = e.class.api_resource
-        raise "Unable to find existing #{resource} with id #{id}\nIf the #{resource} was deleted, remove the `id: -> { #{e.id} }` line."
+        raise "Unable to find existing #{resource} with id #{id}\nIf the #{resource} was deleted, remove the `id: -> { #{e.id.inspect} }` line." unless e.class::VIRTUAL_ID
       end
     end
 


### PR DESCRIPTION
Add log metric record for creating custom metrics from log queries.
https://docs.datadoghq.com/api/latest/logs-metrics/

Note that the user's corresponding to the API/Application key must have the "Logs Public Config API" permissions to hit these APIs, and is separate from permissions to edit custom log metrics via the Datadog UI.

TODO:
- [ ] Changing metric isn't being detected correctly and shows "nothing to do"
- [ ] Check everywhere else TRACKING_FIELD is used, and make sure it'll be compatible
- [ ] Write/update tests