### PR TITLE
Add steps to import SLO alerts to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -114,6 +114,7 @@ end
  - use [datadog monitor UI](https://app.datadoghq.com/monitors/manage) to find a monitor
  - get the `id` from the url
  - run `URL='https://app.datadoghq.com/monitors/123' bundle exec rake kennel:import` and copy the output
+ - import rake task also works with SLO alerts, e.g. `URL='https://app.datadoghq.com/slo/edit/123abc456def123/alerts/789' bundle exec rake kennel:import`
  - find or create a project in `projects/`
  - add the monitor to `parts: [` list, for example:
   ```Ruby

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -129,9 +129,15 @@ module Kennel
         Utils.path_to_url "/monitors##{id}/edit"
       end
 
-      # datadog uses / for show and # for edit as separator in it's links
       def self.parse_url(url)
-        return unless id = url[/\/monitors[\/#](\d+)/, 1]
+        # datadog uses / for show and # for edit as separator in it's links
+        id = url[/\/monitors[\/#](\d+)/, 1]
+
+        # slo alert url
+        id ||= url[/\/slo\/edit\/[a-z\d]{10,}\/alerts\/(\d+)/, 1]
+
+        return unless id
+
         Integer(id)
       end
 

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -64,7 +64,7 @@ module Kennel
       end
 
       def self.parse_url(url)
-        url[/\/slo(\?.*slo_id=|\/edit\/)([a-z\d]{10,})/, 2]
+        url[/\/slo(\?.*slo_id=|\/edit\/)([a-z\d]{10,})(&|$)/, 2]
       end
 
       def resolve_linked_tracking_ids!(id_map, **args)

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -434,6 +434,11 @@ describe Kennel::Models::Monitor do
       Kennel::Models::Monitor.parse_url(url).must_equal 123
     end
 
+    it "parses SLO alert URLs" do
+      url = "https://app.datadoghq.com/slo/edit/123abc456def123/alerts/789"
+      Kennel::Models::Monitor.parse_url(url).must_equal 789
+    end
+
     it "fails to parse other" do
       url = "https://app.datadoghq.com/dashboard/bet-foo-bar?from_ts=1585064592575&to_ts=1585068192575&live=true"
       Kennel::Models::Monitor.parse_url(url).must_be_nil

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -144,18 +144,23 @@ describe Kennel::Models::Slo do
 
   describe ".parse_url" do
     it "parses" do
-      url = "https://app.datadoghq.com/slo?slo_id=123456789123&timeframe=7d&tab=status_and_history"
-      Kennel::Models::Slo.parse_url(url).must_equal "123456789123"
+      url = "https://app.datadoghq.com/slo?slo_id=123abc456def123&timeframe=7d&tab=status_and_history"
+      Kennel::Models::Slo.parse_url(url).must_equal "123abc456def123"
     end
 
     it "parses when other query strings are present" do
-      url = "https://app.datadoghq.com/slo?query=\"bar\"&slo_id=123456789123&timeframe=7d&tab=status_and_history"
-      Kennel::Models::Slo.parse_url(url).must_equal "123456789123"
+      url = "https://app.datadoghq.com/slo?query=\"bar\"&slo_id=123abc456def123&timeframe=7d&tab=status_and_history"
+      Kennel::Models::Slo.parse_url(url).must_equal "123abc456def123"
     end
 
     it "parses url with id" do
-      url = "https://app.datadoghq.com/slo/edit/123456789123"
-      Kennel::Models::Slo.parse_url(url).must_equal "123456789123"
+      url = "https://app.datadoghq.com/slo/edit/123abc456def123"
+      Kennel::Models::Slo.parse_url(url).must_equal "123abc456def123"
+    end
+
+    it "does not parses url with alert" do
+      url = "https://app.datadoghq.com/slo/edit/123abc456def123/alerts/789"
+      Kennel::Models::Slo.parse_url(url).must_be_nil
     end
 
     it "fails to parse other" do


### PR DESCRIPTION
cc @grosser 

Figured out how to use the `rake kennel:import` task to import SLO alerts, I think it'll be useful to have the steps in the README for other people to take advantage of.

Happy to implement any suggestions to improve wording

Thanks!