### PR TITLE
rake kennel:report_fragile

### DIFF
--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -86,7 +86,12 @@ module Kennel
     # Make diff work even though we cannot mass-fetch definitions
     def fill_detail!(api_resource, a, cache)
       args = [api_resource, a.fetch(:id)]
-      full = cache.fetch(args, a.fetch(:modified_at)) { show(*args) }
+      begin
+        full = cache.fetch(args, a.fetch(:modified_at, nil) || a.fetch(:modified)) { show(*args) }
+      rescue KeyError
+        p a
+        raise
+      end
       a.merge!(full)
     end
 

--- a/lib/kennel/dependency_checker.rb
+++ b/lib/kennel/dependency_checker.rb
@@ -1,0 +1,24 @@
+module Kennel
+  module DependencyChecker
+
+    TYPE_DASHBOARD = "dashboard"
+    TYPE_MONITOR = "monitor"
+    TYPE_SLO = "slo"
+    TYPE_SYNTHETIC = "synthetics/tests"
+
+    class HashStruct < Struct
+      def to_json(*args)
+        to_h.to_json(*args)
+      end
+    end
+
+    Dependency = HashStruct.new(:a, :b, keyword_init: true)
+    ResourceId = HashStruct.new(:resource, :id, keyword_init: true)
+    KennelId = HashStruct.new(:id, :in, keyword_init: true)
+
+  end
+end
+
+require_relative 'dependency_checker/item_utils'
+require_relative 'dependency_checker/collector'
+require_relative 'dependency_checker/reporter'

--- a/lib/kennel/dependency_checker/collector.rb
+++ b/lib/kennel/dependency_checker/collector.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Kennel
+  module DependencyChecker
+    class Collector
+
+      def initialize(everything)
+        build_indices(everything)
+      end
+
+      attr_reader :objects, :synthetics_by_monitor_id
+
+      def collect
+        dependencies.map do |dep|
+          {
+            from: render(dep.a),
+            to: render(dep.b),
+          }
+        end
+      end
+
+      private
+
+      def build_indices(everything)
+        @synthetics_by_monitor_id = {}
+
+        @objects = everything.each_with_object({}) do |item, hash|
+          type = item.fetch(:api_resource)
+          key = ResourceId.new(resource: type, id: item[:id].to_s)
+          hash[key] = ItemUtils.new(key, item)
+
+          if type.to_s == TYPE_SYNTHETIC
+            @synthetics_by_monitor_id[item.fetch(:monitor_id).to_s] = key
+          end
+        end
+      end
+
+      def dependencies
+        objects.entries.flat_map do |key, item|
+          (item.dependencies || []).map do |dep|
+            Dependency.new(a: key, b: dep)
+          end
+        end
+      end
+
+      def render(key)
+        resolved_key = resolve(key)
+        item = objects[resolved_key]
+
+        if item.nil?
+          return {
+            key: key,
+            exists: false,
+          }
+        end
+
+        {
+          key: key,
+          exists: true,
+          object: item.object,
+          url: item.url,
+          name: item.name,
+          kennel_id: item.kennel_id,
+          teams: item.tags&.select { |t| t.start_with?("team:") }&.sort&.uniq,
+          author: item.author,
+        }
+      end
+
+      def resolve(key)
+        if !objects.key?(key) && key.resource == TYPE_MONITOR
+          key = synthetics_by_monitor_id[key.id]
+        end
+
+        key
+      end
+
+    end
+  end
+end

--- a/lib/kennel/dependency_checker/item_utils.rb
+++ b/lib/kennel/dependency_checker/item_utils.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative './item_utils/dashboard'
+require_relative './item_utils/monitor'
+require_relative './item_utils/slo'
+require_relative './item_utils/synthetic_test'
+
+module Kennel
+  module DependencyChecker
+    class ItemUtils
+
+      def self.new(key, object)
+        case key.resource.to_s
+        when TYPE_DASHBOARD
+          Dashboard.new(key, object)
+        when TYPE_MONITOR
+          Monitor.new(key, object)
+        when TYPE_SLO
+          SLO.new(key, object)
+        when TYPE_SYNTHETIC
+          SyntheticTest.new(key, object)
+        else
+          raise "Unexpected resource #{key}"
+        end
+      end
+
+    end
+  end
+end

--- a/lib/kennel/dependency_checker/item_utils/base.rb
+++ b/lib/kennel/dependency_checker/item_utils/base.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Kennel
+  module DependencyChecker
+    class ItemUtils
+      class Base
+
+        def initialize(key, object)
+          @resource = key.resource.to_s
+          @id = key.id
+          @object = object
+        end
+
+        attr_reader :resource, :id, :object
+
+        def kennel_id
+          text = kennel_id_text
+          return unless text
+
+          m = text.match(/Managed by kennel (\S+) in ([^,]+),/)
+          m or return
+
+          KennelId.new(id: m[1], in: m[2])
+        end
+
+      end
+    end
+  end
+end

--- a/lib/kennel/dependency_checker/item_utils/base.rb
+++ b/lib/kennel/dependency_checker/item_utils/base.rb
@@ -23,6 +23,25 @@ module Kennel
           KennelId.new(id: m[1], in: m[2])
         end
 
+        protected
+
+        def scan_text_for_dependencies(text, _context)
+          text&.scan(/https:\/\/zendesk\.datadoghq\.com\/dashboard\/(\w\w\w-\w\w\w-\w\w\w)\//) do |id, _|
+            # puts "found dashboard #{id} in #{context}"
+            yield ResourceId.new(resource: "dashboard", id: id)
+          end
+
+          text&.scan(/https:\/\/zendesk\.datadoghq\.com\/monitors\/(\d+)\//) do |id, _|
+            # puts "found monitor #{id} in #{context}"
+            yield ResourceId.new(resource: "monitor", id: id)
+          end
+
+          text&.scan(/https:\/\/zendesk\.datadoghq\.com\/slo\?(?:\w+=\w+&)*slo_id=(\w+)/) do |id, _|
+            # puts "found slo #{id} in #{context}"
+            yield ResourceId.new(resource: "slo", id: id)
+          end
+        end
+
       end
     end
   end

--- a/lib/kennel/dependency_checker/item_utils/dashboard.rb
+++ b/lib/kennel/dependency_checker/item_utils/dashboard.rb
@@ -14,6 +14,7 @@ module Kennel
         def dependencies
           require 'set'
           deps = Set.new
+          scan_text_for_dependencies(object[:description], "dash desc") { |dep| deps.add(dep) }
           each_dependency(object.fetch(:widgets)) { |dep| deps.add(dep) }
           deps
         end
@@ -29,6 +30,7 @@ module Kennel
             end
 
             if t == "note"
+              scan_text_for_dependencies(w[:content], "w note", &block)
               w[:content] = :dummy # human text
             end
 
@@ -75,6 +77,7 @@ module Kennel
             end
 
             w[:custom_links]&.each do |link|
+              scan_text_for_dependencies(link[:link], "w custom links", &block)
               link[:link] = :dummy
               link[:label] = :dummy
             end

--- a/lib/kennel/dependency_checker/item_utils/dashboard.rb
+++ b/lib/kennel/dependency_checker/item_utils/dashboard.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Kennel
+  module DependencyChecker
+    class ItemUtils
+
+      class Dashboard < Base
+        def kennel_id_text
+          object.fetch(:description)
+        end
+
+        def dependencies
+          object.fetch(:widgets).map do |widget|
+            w = widget.fetch(:definition)
+            case w.fetch(:type)
+            when "slo"
+              ResourceId.new(resource: "slo", id: w.fetch(:slo_id).to_s)
+            end
+          end.compact
+        end
+
+        def url
+          "dashboard/#{id}"
+        end
+
+        def name
+          object.fetch(:title)
+        end
+
+        def author
+          object.fetch(:author_handle)
+        end
+
+        def tags
+          nil # :-(
+        end
+      end
+
+    end
+  end
+end

--- a/lib/kennel/dependency_checker/item_utils/dashboard.rb
+++ b/lib/kennel/dependency_checker/item_utils/dashboard.rb
@@ -12,13 +12,85 @@ module Kennel
         end
 
         def dependencies
-          object.fetch(:widgets).map do |widget|
+          require 'set'
+          deps = Set.new
+          each_dependency(object.fetch(:widgets)) { |dep| deps.add(dep) }
+          deps
+        end
+
+        def each_dependency(widgets, &block)
+          widgets.map do |widget|
             w = widget.fetch(:definition)
-            case w.fetch(:type)
-            when "slo"
-              ResourceId.new(resource: "slo", id: w.fetch(:slo_id).to_s)
+            t = w.fetch(:type)
+
+            if t == "group"
+              each_dependency(w[:widgets], &block)
+              w[:widgets] = :dummy
             end
-          end.compact
+
+            if t == "note"
+              w[:content] = :dummy # human text
+            end
+
+            if t == "slo"
+              yield ResourceId.new(resource: "slo", id: w.fetch(:slo_id).to_s)
+              w[:slo_id] = :dummy
+
+              if w[:board_id]
+                yield ResourceId.new(resource: "dashboard", id: w.fetch(:board_id).to_s)
+                w[:board_id] = :dummy
+              end
+            end
+
+            if t == "alert_graph" || t == "alert_value"
+              yield ResourceId.new(resource: "monitor", id: w.fetch(:alert_id).to_s)
+              w[:alert_id] = :dummy
+            end
+
+            if t == "timeseries"
+              w[:markers]&.each do |marker|
+                marker[:value] = :dummy # e.g. "y = 419430400"
+                marker[:label] = :dummy # human text
+              end
+
+              w[:requests]&.each do |req|
+                req[:q]&.gsub!(/\bcheck_id:\s*(\w\w\w-\w\w\w-\w\w\w)\b/) do |id|
+                  yield ResourceId.new(resource: "synthetics/tests", id: id)
+                  "dummy"
+                end
+
+                req[:queries]&.each do |query|
+                  query[:query]&.gsub!(/\bcheck_id:\s*(\w\w\w-\w\w\w-\w\w\w)\b/) do |id|
+                    yield ResourceId.new(resource: "synthetics/tests", id: id)
+                    "dummy"
+                  end
+                end
+
+                req[:metadata]&.each do |meta|
+                  meta[:expression] = :dummy # a comment?
+                end
+              end
+
+              w[:title] = :dummy # human text
+            end
+
+            w[:custom_links]&.each do |link|
+              link[:link] = :dummy
+              link[:label] = :dummy
+            end
+
+            # maybe_ids = []
+            # w.inspect.scan(/\b(\d{6,9}|[0-9a-f]{32}|\w\w\w-\w\w\w-\w\w\w)\b/i) do |maybe_id, _|
+            #   unless maybe_id.match(/^\d+00$/)
+            #     maybe_ids << maybe_id
+            #   end
+            # end
+            #
+            # if maybe_ids.any?
+            #   puts *maybe_ids
+            #   puts JSON.pretty_generate({ widget: w })
+            # end
+          end
         end
 
         def url

--- a/lib/kennel/dependency_checker/item_utils/monitor.rb
+++ b/lib/kennel/dependency_checker/item_utils/monitor.rb
@@ -12,12 +12,19 @@ module Kennel
         end
 
         def dependencies
+          found = Set.new
+
           case object.fetch(:type)
           when "composite"
-            object.fetch(:query).scan(/\d+/).map do |id|
-              ResourceId.new(resource: "monitor", id: id.to_s)
+            object.fetch(:query).scan(/\d+/).each  do |id|
+              found << ResourceId.new(resource: "monitor", id: id.to_s)
             end
           end
+
+          scan_text_for_dependencies(object[:message], "mon message") { |dep| found.add(dep) }
+          scan_text_for_dependencies(object.dig(:options, :escalation_message), "mon esc") { |dep| found.add(dep) }
+
+          found
         end
 
         def url

--- a/lib/kennel/dependency_checker/item_utils/monitor.rb
+++ b/lib/kennel/dependency_checker/item_utils/monitor.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Kennel
+  module DependencyChecker
+    class ItemUtils
+
+      class Monitor < Base
+        def kennel_id_text
+          object.fetch(:message)
+        end
+
+        def dependencies
+          case object.fetch(:type)
+          when "composite"
+            object.fetch(:query).scan(/\d+/).map do |id|
+              ResourceId.new(resource: "monitor", id: id.to_s)
+            end
+          end
+        end
+
+        def url
+          "monitors/#{id}"
+        end
+
+        def name
+          object.fetch(:name)
+        end
+
+        def author
+          object.fetch(:creator).fetch(:handle)
+        end
+
+        def tags
+          object.fetch(:tags)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/kennel/dependency_checker/item_utils/slo.rb
+++ b/lib/kennel/dependency_checker/item_utils/slo.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Kennel
+  module DependencyChecker
+    class ItemUtils
+
+      class SLO < Base
+        def kennel_id_text
+          object.fetch(:description)
+        end
+
+        def dependencies
+          case object.fetch(:type)
+          when "monitor"
+            object.fetch(:monitor_ids).map do |id|
+              ResourceId.new(resource: "monitor", id: id.to_s)
+            end
+          end
+        end
+
+        def url
+          "slo?slo_id=#{id}"
+        end
+
+        def name
+          object.fetch(:name)
+        end
+
+        def author
+          object.fetch(:creator).fetch(:handle)
+        end
+
+        def tags
+          object.fetch(:tags) + object.fetch(:monitor_tags)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/kennel/dependency_checker/item_utils/slo.rb
+++ b/lib/kennel/dependency_checker/item_utils/slo.rb
@@ -12,12 +12,18 @@ module Kennel
         end
 
         def dependencies
+          found = Set.new
+
           case object.fetch(:type)
           when "monitor"
-            object.fetch(:monitor_ids).map do |id|
-              ResourceId.new(resource: "monitor", id: id.to_s)
+            object.fetch(:monitor_ids).each do |id|
+              found << ResourceId.new(resource: "monitor", id: id.to_s)
             end
           end
+
+          scan_text_for_dependencies(object[:description], "slo desc") { |dep| found.add(dep) }
+
+          found
         end
 
         def url

--- a/lib/kennel/dependency_checker/item_utils/synthetic_test.rb
+++ b/lib/kennel/dependency_checker/item_utils/synthetic_test.rb
@@ -12,7 +12,11 @@ module Kennel
         end
 
         def dependencies
-          nil
+          found = Set.new
+
+          scan_text_for_dependencies(object[:message], "synth message") { |dep| found.add(dep) }
+
+          found
         end
 
         def url

--- a/lib/kennel/dependency_checker/item_utils/synthetic_test.rb
+++ b/lib/kennel/dependency_checker/item_utils/synthetic_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Kennel
+  module DependencyChecker
+    class ItemUtils
+
+      class SyntheticTest < Base
+        def kennel_id_text
+          nil
+        end
+
+        def dependencies
+          nil
+        end
+
+        def url
+          "synthetics/details/#{id}"
+        end
+
+        def name
+          object.fetch(:name)
+        end
+
+        def author
+          nil
+        end
+
+        def tags
+          object.fetch(:tags)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/kennel/dependency_checker/item_utils/synthetic_test.rb
+++ b/lib/kennel/dependency_checker/item_utils/synthetic_test.rb
@@ -8,7 +8,7 @@ module Kennel
 
       class SyntheticTest < Base
         def kennel_id_text
-          nil
+          object.fetch(:message)
         end
 
         def dependencies

--- a/lib/kennel/dependency_checker/reporter.rb
+++ b/lib/kennel/dependency_checker/reporter.rb
@@ -11,45 +11,43 @@ module Kennel
       end
 
       def report(dependencies)
-        fragile = dependencies.map do |dep|
+        deps = dependencies.map do |dep|
           from, to = dep[:from], dep[:to]
 
           owner = from[:teams]&.any? ? from[:teams].join(" ") : from[:author]
 
-          if !to[:exists]
-            # broken (maybe kennel maybe not)
-            if from[:kennel_id]
-              {
-                code: :broken_kennel_object,
-                url: resolve_url(from[:url]),
-                name: from[:name],
-                owner: owner,
-                missing_dependency: to[:key],
-                kennel_id: from[:kennel_id],
-              }
-            else
-              {
-                code: :broken_non_kennel_object,
-                url: resolve_url(from[:url]),
-                name: from[:name],
-                owner: owner,
-                missing_dependency: to[:key],
-              }
-            end
-          elsif from[:kennel_id] && !to[:kennel_id]
-            {
-              code: :fragile_kennel_object,
+          from_type = from[:kennel_id] ? :kennel : :loose
+          to_type = if to[:exists]
+                      to[:kennel_id] ? :kennel : :loose
+                    else
+                      :dead
+                    end
+
+          {
+            code: "from_#{from_type}_to_#{to_type}",
+            from: {
+              key: from[:key],
+              exists: from[:exists], # always true
               url: resolve_url(from[:url]),
               name: from[:name],
               owner: owner,
-              non_kennel_dependency: to[:key],
               kennel_id: from[:kennel_id],
-            }
-          end
-        end.compact
+              # rest: dep[:from],
+            },
+            to: {
+              key: to[:key],
+              exists: to[:exists],
+              kennel_id: to[:kennel_id],
+              # rest: dep[:to],
+            },
+          }
+        end
 
-        fragile.sort_by do |item|
-          [item[:url], item[:missing_dependency]&.id || item[:non_kennel_dependency].id]
+        deps.sort_by do |item|
+          [
+            item[:from][:key].resource, item[:from][:key].id,
+            item[:to][:key].resource, item[:to][:key].id,
+          ]
         end
       end
 

--- a/lib/kennel/dependency_checker/reporter.rb
+++ b/lib/kennel/dependency_checker/reporter.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+module Kennel
+  module DependencyChecker
+    class Reporter
+
+      def initialize(base_url: nil)
+        @base_url = (URI.parse(base_url) if base_url)
+      end
+
+      def report(dependencies)
+        fragile = dependencies.map do |dep|
+          from, to = dep[:from], dep[:to]
+
+          owner = from[:teams]&.any? ? from[:teams].join(" ") : from[:author]
+
+          if !to[:exists]
+            # broken (maybe kennel maybe not)
+            if from[:kennel_id]
+              {
+                code: :broken_kennel_object,
+                url: resolve_url(from[:url]),
+                name: from[:name],
+                owner: owner,
+                missing_dependency: to[:key],
+                kennel_id: from[:kennel_id],
+              }
+            else
+              {
+                code: :broken_non_kennel_object,
+                url: resolve_url(from[:url]),
+                name: from[:name],
+                owner: owner,
+                missing_dependency: to[:key],
+              }
+            end
+          elsif from[:kennel_id] && !to[:kennel_id]
+            {
+              code: :fragile_kennel_object,
+              url: resolve_url(from[:url]),
+              name: from[:name],
+              owner: owner,
+              non_kennel_dependency: to[:key],
+              kennel_id: from[:kennel_id],
+            }
+          end
+        end.compact
+
+        fragile.sort_by do |item|
+          [item[:url], item[:missing_dependency]&.id || item[:non_kennel_dependency].id]
+        end
+      end
+
+      private
+
+      def resolve_url(url)
+        if @base_url
+          (@base_url + url).to_s
+        else
+          url
+        end
+      end
+
+    end
+  end
+end

--- a/lib/kennel/resources.rb
+++ b/lib/kennel/resources.rb
@@ -1,0 +1,56 @@
+require 'json'
+require 'tempfile'
+
+module Kennel
+  class Resources
+    def self.each(resources: nil)
+      return enum_for(resources: resources) unless block_given?
+
+      resources ||= Kennel::Models::Record.api_resource_map.keys
+      api = Kennel.send(:api)
+      list = nil
+
+      resources.each do |resource|
+        Kennel::Progress.progress("Downloading #{resource}") do
+          list = api.list(resource)
+          api.fill_details!(resource, list)
+        end
+
+        list.each do |r|
+          r[:api_resource] = resource
+          yield r
+        end
+      end
+    end
+
+    def self.cached_each(filename:, max_age:, &block)
+      return enum_for(:cached_each, filename: filename, max_age: max_age) unless block_given?
+
+      File.open(filename, 'r') do |f|
+        age = (Time.now - f.stat.mtime)
+        raise Errno::ENOENT if age > max_age
+        Kennel.err.puts "Using #{age.to_i}-seconds-old #{filename}"
+        f.each_line do |line|
+          block.call(JSON.parse(line, symbolize_names: true))
+        end
+      end
+
+      nil
+    rescue Errno::ENOENT
+      Tempfile.open(filename, File.dirname(filename)) do |f|
+        each do |r|
+          f.puts(JSON.generate(r))
+          block.call(r)
+        end
+
+        f.flush
+        f.chmod 0o644
+        File.rename f.path, filename
+      end
+
+      Kennel.err.puts "Saved results to #{filename}"
+
+      nil
+    end
+  end
+end

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -207,7 +207,6 @@ module Kennel
     end
 
     def print_plan(step, list, color)
-      return if list.empty?
       list.each do |_, e, a, diff|
         klass = (e ? e.class : a.fetch(:klass))
         Kennel.out.puts Utils.color(color, "#{step} #{klass.api_resource} #{e&.tracking_id || a.fetch(:tracking_id)}")

--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -71,12 +71,12 @@ namespace :kennel do
     dependencies = Kennel::DependencyChecker::Collector.new(everything)
       .collect
 
-    fragile = Kennel::DependencyChecker::Reporter.new(base_url: ENV['BASE_URL'])
+    report = Kennel::DependencyChecker::Reporter.new(base_url: ENV['BASE_URL'])
       .report(dependencies)
 
     out = "tmp/fragile.json"
     Tempfile.open(out, File.dirname(out)) do |f|
-      f.puts JSON.generate(fragile: fragile)
+      f.puts JSON.generate(dependencies: report)
       f.flush
       f.chmod 0o644
       File.rename f.path, out


### PR DESCRIPTION
### Description

Provides a task `kennel:report_fragile`, which writes a JSON-formatted "fragile objects" report to `tmp/cache/report_fragile.json`.

As part of doing this, there's now a `Kennel::Resources.each` (and `cached_each`), and (mostly for debugging) rake tasks `kennel:dump_resources` and `kennel:dump_resources_cached`. `Kennel::Resources` could be used to reimplement `kennel:dump`.

`Kennel::DependencyChecker::ItemUtils` almost certainly duplicates functionality already found in kennel.

The fact that the DependencyChecker (and the rake task) recognises `team:X` tags as being a form of owner, is somewhat Zendesk-specific.

### References
 - https://zendesk.slack.com/archives/C81T33XTK/p1622548501034800
 - https://gist.github.com/zdrve/403ecc861d08d2f700749a20c0aa06f6

### Pre-Merge:
 - [ ] tested changes with `PROJECT=foo rake kennel:update_datadog` (not covered by Github Action)
 - [ ] confirmed that the previous master CI has ran successfully: [![CI](https://github.com/zendesk/kennel/workflows/CI/badge.svg)](https://github.com/zendesk/kennel/actions?query=branch%3Amaster+workflow%3ACI)

