### PR TITLE
query value autoscale either was never the default or changed

### DIFF
--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -46,7 +46,6 @@ module Kennel
           font_size: "14"
         },
         "query_value" => {
-          autoscale: true,
           time: {},
           title_align: "left",
           title_size: "16"


### PR DESCRIPTION
creating a new widget via api results in autoscale being off
but kennel refuses the send the true value when autoscale is not set in the api either
so we ended up with being unable to set autoscale