### PR TITLE
Add new_group_delay setting to monitors

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -19,6 +19,7 @@ module Kennel
       MONITOR_OPTION_DEFAULTS = {
         evaluation_delay: nil,
         new_host_delay: 300,
+        new_group_delay: 60,
         timeout_h: 0,
         renotify_interval: 0,
         notify_audit: false,
@@ -31,7 +32,7 @@ module Kennel
       settings(
         :query, :name, :message, :escalation_message, :critical, :type, :renotify_interval, :warning, :timeout_h, :evaluation_delay,
         :ok, :no_data_timeframe, :notify_no_data, :notify_audit, :tags, :critical_recovery, :warning_recovery, :require_full_window,
-        :threshold_windows, :new_host_delay, :priority
+        :threshold_windows, :new_host_delay, :new_group_delay, :priority
       )
 
       defaults(
@@ -45,6 +46,7 @@ module Kennel
         no_data_timeframe: -> { 60 },
         notify_audit: -> { MONITOR_OPTION_DEFAULTS.fetch(:notify_audit) },
         new_host_delay: -> { MONITOR_OPTION_DEFAULTS.fetch(:new_host_delay) },
+        new_group_delay: -> { MONITOR_OPTION_DEFAULTS.fetch(:new_group_delay) },
         tags: -> { @project.tags },
         timeout_h: -> { MONITOR_OPTION_DEFAULTS.fetch(:timeout_h) },
         evaluation_delay: -> { MONITOR_OPTION_DEFAULTS.fetch(:evaluation_delay) },
@@ -70,6 +72,7 @@ module Kennel
             notify_audit: notify_audit,
             require_full_window: require_full_window,
             new_host_delay: new_host_delay,
+            new_group_delay: new_group_delay,
             include_tags: true,
             escalation_message: Utils.presence(escalation_message.strip),
             evaluation_delay: evaluation_delay,

--- a/test/kennel/importer_test.rb
+++ b/test/kennel/importer_test.rb
@@ -281,6 +281,7 @@ describe Kennel::Importer do
           include_tags: true,
           no_data_timeframe: nil,
           new_host_delay: 300,
+          new_group_delay: 60,
           require_full_window: false,
           notify_no_data: false,
           renotify_interval: 120,

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -35,6 +35,7 @@ describe Kennel::Models::Monitor do
         notify_audit: false,
         require_full_window: true,
         new_host_delay: 300,
+        new_group_delay: 60,
         include_tags: true,
         escalation_message: nil,
         evaluation_delay: nil,
@@ -194,6 +195,10 @@ describe Kennel::Models::Monitor do
 
     it "can set new_host_delay" do
       monitor(new_host_delay: -> { 300 }).as_json.dig(:options, :new_host_delay).must_equal 300
+    end
+
+    it "can set new_group_delay" do
+      monitor(new_group_delay: -> { 120 }).as_json.dig(:options, :new_group_delay).must_equal 120
     end
 
     it "can set threshold_windows" do


### PR DESCRIPTION
To enable the ability to alert monitors on new groups, we need to pass in a value for new_group_delay

The default for this value is 60: https://docs.datadoghq.com/monitors/guide/monitor_api_options/

Setting this as a default on the monitor so it will work when groups are defined in the query.