### PR TITLE
Add padlock icon to synthetic test names

### DIFF
--- a/lib/kennel/models/synthetic_test.rb
+++ b/lib/kennel/models/synthetic_test.rb
@@ -26,7 +26,7 @@ module Kennel
           type: type,
           subtype: subtype,
           options: options,
-          name: name,
+          name: "#{name}#{LOCK}",
           locations: locations == :all ? LOCATIONS : locations
         }
 

--- a/test/kennel/models/synthetic_test_test.rb
+++ b/test/kennel/models/synthetic_test_test.rb
@@ -35,7 +35,7 @@ describe Kennel::Models::SyntheticTest do
       type: "api",
       subtype: "http",
       options: {},
-      name: "foo",
+      name: "foo\u{1F512}",
       locations: ["l1"]
     }
   end


### PR DESCRIPTION
Like we do for the other record types.