### PR TITLE
Syncer bugs

### DIFF
--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -263,7 +263,8 @@ module Kennel
 
       actual.each do |a|
         next unless tracking_id = a.fetch(:tracking_id)
-        next unless @id_map.get(a.fetch(:klass).api_resource, tracking_id)
+        next unless @id_map.get(a.fetch(:klass).api_resource, tracking_id) \
+          || (@project_filter && !tracking_id.start_with?("#{@project_filter}:"))
 
         @id_map.set(a.fetch(:klass).api_resource, tracking_id, a.fetch(:id))
         if a[:klass].api_resource == "synthetics/tests"

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -256,6 +256,9 @@ module Kennel
     def populate_id_map(expected, actual)
       expected.each do |e|
         @id_map.set_new(e.class.api_resource, e.tracking_id)
+        if e.class.api_resource == "synthetics/tests"
+          @id_map.set_new(Kennel::Models::Monitor.api_resource, e.tracking_id)
+        end
       end
 
       actual.each do |a|

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -179,6 +179,16 @@ describe Kennel::Syncer do
         monitors << monitor_api_response("a", "b", id: 123, message: "")
         output.must_equal "Plan:\nNothing to do\n"
       end
+
+      it "can resolve by tracking id outside of the filter" do
+        # project_filter[0] = nil
+        monitors << monitor_api_response("xxx", "x", id: 123)
+        expected << slo("a", "b", monitor_ids: ["xxx:x"])
+        output.must_equal <<~OUTPUT
+          Plan:
+          Create slo a:b
+        OUTPUT
+      end
     end
 
     it "shows long updates nicely" do


### PR DESCRIPTION
Two bug fixes:

 * when resolving a monitor ID using a synthetic, that should also work for synthetics being created during this run
 * when using a project filter, it should be possible to refer to existing items outside of the filter
