### PR TITLE
Turn missing imports into a warning, if running master ci

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -42,9 +42,10 @@ module Kennel
 
   @out = $stdout
   @err = $stderr
+  @strict_imports = true
 
   class << self
-    attr_accessor :out, :err
+    attr_accessor :out, :err, :strict_imports
 
     def generate
       store generated

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -18,6 +18,7 @@ module Kennel
       if noop?
         Kennel.out.puts Utils.color(:green, "Nothing to do")
       else
+        @warnings.each { |message| Kennel.out.puts Utils.color(:yellow, "Warning: #{message}") }
         print_plan "Create", @create, :green
         print_plan "Update", @update, :yellow
         print_plan "Delete", @delete, :red
@@ -120,6 +121,7 @@ module Kennel
     end
 
     def calculate_diff
+      @warnings = []
       @update = []
       @delete = []
       @id_map = IdMap.new
@@ -181,7 +183,11 @@ module Kennel
       @expected.each do |e|
         next unless id = e.id
         resource = e.class.api_resource
-        raise "Unable to find existing #{resource} with id #{id}\nIf the #{resource} was deleted, remove the `id: -> { #{e.id} }` line."
+        if Kennel.strict_imports
+          raise "Unable to find existing #{resource} with id #{id}\nIf the #{resource} was deleted, remove the `id: -> { #{id} }` line."
+        else
+          @warnings << "#{resource} #{e.tracking_id} specifies id #{id}, but no such #{resource} exists. 'id' will be ignored. Remove the `id: -> { #{id} }` line."
+        end
       end
     end
 

--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -76,6 +76,7 @@ namespace :kennel do
     is_push = (ENV["TRAVIS_PULL_REQUEST"] == "false" || ENV["GITHUB_EVENT_NAME"] == "push")
     task_name =
       if on_default_branch && is_push
+        Kennel.strict_imports = false
         "kennel:update_datadog"
       else
         "kennel:plan" # show plan in CI logs

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -363,10 +363,27 @@ describe Kennel::Syncer do
         TEXT
       end
 
-      it "complains when id was not found" do
+      it "complains when id was not found (with strict imports)" do
         monitors.pop
         e = assert_raises(RuntimeError) { syncer.plan }
         e.message.must_equal "Unable to find existing monitor with id 234\nIf the monitor was deleted, remove the `id: -> { 234 }` line."
+      end
+
+      it "complains when id was not found (without strict imports)" do
+        old_setting = Kennel.strict_imports
+
+        begin
+          Kennel.strict_imports = false
+          monitors.pop
+
+          output.must_equal <<~TXT
+            Plan:
+            Warning: monitor a:b specifies id 234, but no such monitor exists. 'id' will be ignored. Remove the `id: -> { 234 }` line.
+            Create monitor a:b
+          TXT
+        ensure
+          Kennel.strict_imports = old_setting
+        end
       end
     end
   end

--- a/test/kennel/tasks_test.rb
+++ b/test/kennel/tasks_test.rb
@@ -3,7 +3,7 @@ require_relative "../test_helper"
 require "rake"
 require "kennel/tasks"
 
-SingleCov.covered! uncovered: 37 # TODO: reduce this
+SingleCov.covered! uncovered: 38 # TODO: reduce this
 
 describe "tasks" do
   with_env DATADOG_APP_KEY: "foo", DATADOG_API_KEY: "bar"


### PR DESCRIPTION
(These examples force a failure by changing both an `id` and `kennel_id` from a clean codebase):

Non-master CI:

```
harvey:kennel revans$ with-ruby - bundle exec rake generate kennel:ci
Generating ... 2.84s
Storing ... 4.39s
Downloading definitions ... 8.55s
Diffing ... -rake aborted!
Unable to find existing dashboard with id a33-zbi-zzz
If the dashboard was deleted, remove the `id: -> { a33-zbi-zzz }` line.
```

Master CI:

```
harvey:kennel revans$ GITHUB_REF=refs/heads/master GITHUB_EVENT_NAME=push  with-ruby - bundle exec rake generate kennel:ci
Generating ... 3.13s
Storing ... 4.58s
Downloading definitions ... 8.9s
Diffing ... 15.08s
Plan:
Warning: dashboard admin_centre:admin-center-errors-dashboard2 specifies id a33-zbi-zzz, but no such dashboard exists. 'id' will be ignored. Remove the `id: -> { a33-zbi-zzz }` line.
Create dashboard admin_centre:admin-center-errors-dashboard2
Delete dashboard admin_centre:admin-center-errors-dashboard
Execute Plan ? -  press 'y' to continue: ^C
```

Note that this introduces one extra line of code in an area that already lacks test coverage.
