### PR TITLE
Refuse update of dashboard layout_type

### DIFF
--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -205,9 +205,9 @@ module Kennel
         end
       end
 
-      def validate_update!(actual, diffs)
-        if diff = diffs.find { |diff| diff[1] == "layout_type" }
-          raise "Datadog does not allow update of #{diff[1]} (in #{tracking_id}, #{diff[2].inspect} -> #{diff[3].inspect})"
+      def validate_update!(_actual, diffs)
+        if bad_diff = diffs.find { |diff| diff[1] == "layout_type" }
+          raise "Datadog does not allow update of #{bad_diff[1]} (in #{tracking_id}, #{bad_diff[2].inspect} -> #{bad_diff[3].inspect})"
         end
       end
 

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -205,6 +205,12 @@ module Kennel
         end
       end
 
+      def validate_update!(actual, diffs)
+        if diff = diffs.find { |diff| diff[1] == "layout_type" }
+          raise "Datadog does not allow update of #{diff[1]} (in #{tracking_id}, #{diff[2].inspect} -> #{diff[3].inspect})"
+        end
+      end
+
       private
 
       # creates queries from metadata to avoid having to keep q and expression in sync

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -126,9 +126,9 @@ module Kennel
         end
       end
 
-      def validate_update!(actual, diffs)
-        if diff = diffs.find { |diff| diff[1] == "type" }
-          raise "Datadog does not allow update of #{diff[1]} (in #{tracking_id}, #{diff[2].inspect} -> #{diff[3].inspect})"
+      def validate_update!(_actual, diffs)
+        if bad_diff = diffs.find { |diff| diff[1] == "type" }
+          raise "Datadog does not allow update of #{bad_diff[1]} (in #{tracking_id}, #{bad_diff[2].inspect} -> #{bad_diff[3].inspect})"
         end
       end
 

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -126,6 +126,12 @@ module Kennel
         end
       end
 
+      def validate_update!(actual, diffs)
+        if diff = diffs.find { |diff| diff[1] == "type" }
+          raise "Datadog does not allow update of #{diff[1]} (in #{tracking_id}, #{diff[2].inspect} -> #{diff[3].inspect})"
+        end
+      end
+
       def self.api_resource
         "monitor"
       end

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -36,6 +36,9 @@ module Kennel
             raise("did not find tracking id in #{value}")
         end
 
+        def validate_delete!(_actual)
+        end
+
         private
 
         def normalize(_expected, actual)
@@ -96,6 +99,12 @@ module Kennel
 
       def remove_tracking_id
         self.class.remove_tracking_id(as_json)
+      end
+
+      def validate_create!
+      end
+
+      def validate_update!(_actual, _diffs)
       end
 
       private

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -36,9 +36,6 @@ module Kennel
             raise("did not find tracking id in #{value}")
         end
 
-        def validate_delete!(_actual)
-        end
-
         private
 
         def normalize(_expected, actual)
@@ -99,9 +96,6 @@ module Kennel
 
       def remove_tracking_id
         self.class.remove_tracking_id(as_json)
-      end
-
-      def validate_create!
       end
 
       def validate_update!(_actual, _diffs)

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -9,6 +9,7 @@ module Kennel
       @project_filter = project
       @expected = expected
       calculate_diff
+      validate_plan
       prevent_irreversible_partial_updates
     end
 
@@ -207,6 +208,22 @@ module Kennel
         else
           Kennel.out.puts "  #{type}#{field} #{old} -> #{new}"
         end
+      end
+    end
+
+    # We've already validated the desired objects ('generated') in isolation.
+    # Now that we have made the plan, we can perform some more validation.
+    def validate_plan
+      @create.each do |_, expected|
+        expected.validate_create!
+      end
+
+      @update.each do |_, expected, actual, diffs|
+        expected.validate_update!(actual, diffs)
+      end
+
+      @delete.each do |_, _, actual|
+        actual.fetch(:klass).validate_delete!(actual)
       end
     end
 

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -214,16 +214,8 @@ module Kennel
     # We've already validated the desired objects ('generated') in isolation.
     # Now that we have made the plan, we can perform some more validation.
     def validate_plan
-      @create.each do |_, expected|
-        expected.validate_create!
-      end
-
       @update.each do |_, expected, actual, diffs|
         expected.validate_update!(actual, diffs)
-      end
-
-      @delete.each do |_, _, actual|
-        actual.fetch(:klass).validate_delete!(actual)
       end
     end
 

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -362,6 +362,31 @@ describe Kennel::Models::Dashboard do
     end
   end
 
+  describe "#validate_update!" do
+    it "allows update of title" do
+      existing = dashboard_with_requests
+      wanted = existing.as_json.merge("title" => "new #{existing.title}")
+      diffs = [
+        ["~", "title", existing.title, wanted.fetch("title")]
+      ]
+
+      # Does not raise
+      existing.validate_update!(wanted, diffs)
+    end
+
+    it "disallows update of layout_type" do
+      existing = dashboard_with_requests
+      wanted = existing.as_json.merge("layout_type" => "new #{existing.layout_type}")
+      diffs = [
+        ["~", "layout_type", existing.layout_type, wanted.fetch("layout_type")]
+      ]
+      exception = assert_raises RuntimeError do
+        existing.validate_update!(wanted, diffs)
+      end
+      exception.message.must_match(/datadog.*allow.*layout_type/i)
+    end
+  end
+
   describe ".api_resource" do
     it "is dashboard" do
       Kennel::Models::Dashboard.api_resource.must_equal "dashboard"

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -446,6 +446,31 @@ describe Kennel::Models::Monitor do
     end
   end
 
+  describe "#validate_update!" do
+    it "allows update of name" do
+      existing = monitor
+      wanted = existing.as_json.merge("name" => "new #{existing.name}")
+      diffs = [
+        ["~", "name", existing.name, wanted.fetch("name")]
+      ]
+
+      # Does not raise
+      existing.validate_update!(wanted, diffs)
+    end
+
+    it "disallows update of type" do
+      existing = monitor
+      wanted = existing.as_json.merge("type" => "new #{existing.type}")
+      diffs = [
+        ["~", "type", existing.type, wanted.fetch("type")]
+      ]
+      exception = assert_raises RuntimeError do
+        existing.validate_update!(wanted, diffs)
+      end
+      exception.message.must_match(/datadog.*allow.*type/i)
+    end
+  end
+
   describe ".url" do
     it "shows path" do
       Kennel::Models::Monitor.url(111).must_equal "/monitors#111/edit"


### PR DESCRIPTION
A sketch. What do you think?

We get post-merge failures like this one https://github.com/zendesk/kennel/runs/5622881439?check_suite_focus=true : 

```json
{"errors": ["'layout_type' is not editable for existing dashboards. This dashboard uses ordered layout."]}
```

It could be good to trap those before merge. This is one way of doing that.

But: how far do we want to go down the path of reproducing datadog's validations in kennel?
