### PR TITLE
dont alert on no data during renotify if "no data" option is selected

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -76,8 +76,9 @@ module Kennel
             escalation_message: Utils.presence(escalation_message.strip),
             evaluation_delay: evaluation_delay,
             locked: false, # setting this to true prevents any edit and breaks updates when using replace workflow
-            renotify_interval: renotify_interval || 0
-          }
+            renotify_interval: renotify_interval || 0,
+            renotify_statuses: notify_no_data ? ["alert", "no data"] : ["alert"]
+        }
         }
 
         data[:id] = id if id

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -81,12 +81,6 @@ module Kennel
         }
 
         data[:id] = id if id
-        if renotify_interval != 0
-          statuses = ["alert"]
-          statuses << "no data" if notify_no_data
-          statuses << "warn" if warning
-          data[:options][:renotify_statuses] = statuses
-        end
 
         options = data[:options]
         if data.fetch(:type) != "composite"
@@ -116,6 +110,14 @@ module Kennel
 
         # Datadog requires only either new_group_delay or new_host_delay, never both
         options.delete(options[:new_group_delay] ? :new_host_delay : :new_group_delay)
+
+        # Add in statuses where we would re notify on. Possible values: alert, no data, warn
+        if options[:renotify_interval] != 0
+          statuses = ["alert"]
+          statuses << "no data" if options[:notify_no_data]
+          statuses << "warn" if options.dig(:thresholds, :warning)
+          options[:renotify_statuses] = statuses
+        end
 
         validate_json(data) if validate
 

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -76,12 +76,15 @@ module Kennel
             escalation_message: Utils.presence(escalation_message.strip),
             evaluation_delay: evaluation_delay,
             locked: false, # setting this to true prevents any edit and breaks updates when using replace workflow
-            renotify_interval: renotify_interval || 0,
-            renotify_statuses: notify_no_data ? ["alert", "no data"] : ["alert"]
-        }
+            renotify_interval: renotify_interval || 0
+          }
         }
 
         data[:id] = id if id
+
+        if renotify_interval != 0 && !notify_no_data
+          data[:options][:renotify_statuses] =["alert"]
+        end
 
         options = data[:options]
         if data.fetch(:type) != "composite"

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -81,9 +81,11 @@ module Kennel
         }
 
         data[:id] = id if id
-
-        if renotify_interval != 0 && !notify_no_data
-          data[:options][:renotify_statuses] =["alert"]
+        if renotify_interval != 0
+          statuses = ["alert"]
+          statuses << "no data" if notify_no_data
+          statuses << "warn" if warning
+          data[:options][:renotify_statuses] = statuses
         end
 
         options = data[:options]

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -41,10 +41,6 @@ describe Kennel::Models::Monitor do
         evaluation_delay: nil,
         locked: false,
         renotify_interval: 0,
-        renotify_statuses: [
-          "alert",
-          "no data"
-        ],
         thresholds: { critical: 123.0 }
       }
     }
@@ -159,10 +155,18 @@ describe Kennel::Models::Monitor do
       ).as_json[:options][:no_data_timeframe].must_be_nil
     end
 
-    it "sets renotify_statuses to alert only when notify_no_data is false" do
+    it "sets renotify_statuses to alert only when renotify_interval is greater than 1" do
       monitor(
+        renotify_interval: -> { 10 },
         notify_no_data: -> { false },
         ).as_json[:options][:renotify_statuses].must_equal ["alert"]
+    end
+
+    it "do not set renotify_statuses when renotify_interval is 0" do
+      monitor(
+        renotify_interval: -> { 0 },
+        notify_no_data: -> { false },
+        ).as_json[:options][:renotify_statuses].must_be_nil
     end
 
     it "can set notify_audit" do

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -155,11 +155,27 @@ describe Kennel::Models::Monitor do
       ).as_json[:options][:no_data_timeframe].must_be_nil
     end
 
-    it "sets renotify_statuses to alert only when renotify_interval is greater than 1" do
+    it "sets renotify_statuses to alert only when renotify_interval is greater than 1, and notify no data and warning are disabled" do
       monitor(
         renotify_interval: -> { 10 },
         notify_no_data: -> { false },
         ).as_json[:options][:renotify_statuses].must_equal ["alert"]
+    end
+
+    it "sets renotify_statuses to alert and warn when renotify_interval and warning are set" do
+      monitor(
+        renotify_interval: -> { 10 },
+        notify_no_data: -> { false },
+        warning: -> { 10 },
+        ).as_json[:options][:renotify_statuses].must_equal ["alert", "warn"]
+    end
+
+    it "sets renotify_statuses when renotify_interval, warning and no data are set" do
+      monitor(
+        renotify_interval: -> { 10 },
+        notify_no_data: -> { true },
+        warning: -> { 10 },
+        ).as_json[:options][:renotify_statuses].must_equal ["alert", "no data", "warn"]
     end
 
     it "do not set renotify_statuses when renotify_interval is 0" do

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -41,6 +41,10 @@ describe Kennel::Models::Monitor do
         evaluation_delay: nil,
         locked: false,
         renotify_interval: 0,
+        renotify_statuses: [
+          "alert",
+          "no data"
+        ],
         thresholds: { critical: 123.0 }
       }
     }
@@ -153,6 +157,12 @@ describe Kennel::Models::Monitor do
         notify_no_data: -> { false },
         no_data_timeframe: -> { 2 }
       ).as_json[:options][:no_data_timeframe].must_be_nil
+    end
+
+    it "sets renotify_statuses to alert only when notify_no_data is false" do
+      monitor(
+        notify_no_data: -> { false },
+        ).as_json[:options][:renotify_statuses].must_equal ["alert"]
     end
 
     it "can set notify_audit" do

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -158,31 +158,36 @@ describe Kennel::Models::Monitor do
     it "sets renotify_statuses to alert only when renotify_interval is greater than 1, and notify no data and warning are disabled" do
       monitor(
         renotify_interval: -> { 10 },
-        notify_no_data: -> { false },
-        ).as_json[:options][:renotify_statuses].must_equal ["alert"]
+        notify_no_data: -> { false }
+      ).as_json[:options][:renotify_statuses].must_equal ["alert"]
     end
 
     it "sets renotify_statuses to alert and warn when renotify_interval and warning are set" do
       monitor(
         renotify_interval: -> { 10 },
         notify_no_data: -> { false },
-        warning: -> { 10 },
-        ).as_json[:options][:renotify_statuses].must_equal ["alert", "warn"]
+        warning: -> { 10 }
+      ).as_json[:options][:renotify_statuses].must_equal ["alert", "warn"]
     end
 
     it "sets renotify_statuses when renotify_interval, warning and no data are set" do
       monitor(
         renotify_interval: -> { 10 },
         notify_no_data: -> { true },
-        warning: -> { 10 },
-        ).as_json[:options][:renotify_statuses].must_equal ["alert", "no data", "warn"]
+        warning: -> { 10 }
+      ).as_json[:options][:renotify_statuses].must_equal ["alert", "no data", "warn"]
     end
 
     it "do not set renotify_statuses when renotify_interval is 0" do
       monitor(
-        renotify_interval: -> { 0 },
-        notify_no_data: -> { false },
-        ).as_json[:options][:renotify_statuses].must_be_nil
+        renotify_interval: -> { 0 }
+      ).as_json[:options][:renotify_statuses].must_be_nil
+    end
+
+    it "do not set renotify_statuses when renotify_interval is not defined" do
+      monitor(
+        renotify_interval: -> {}
+      ).as_json[:options][:renotify_statuses].must_be_nil
     end
 
     it "can set notify_audit" do


### PR DESCRIPTION
Currently if renotify option is selected, the monitor will renotify on both alert and no data. 
We should only do renotify on alert if `notify_no_data` option is not selected.

How the monitor json looks like
```
{
	"name": "som name",
	"type": "query alert",
	"query": xxx
	"options": {
		"thresholds": {
			"critical": 80
		},
		"notify_audit": false,
		"require_full_window": false,
		"notify_no_data": false,
		"renotify_interval": 30,
		"silenced": {},
		"include_tags": true,
		"new_host_delay": 300,
		"escalation_message": "",
		"renotify_statuses": [
			"alert",
			"no data",
			"warn"
		]
	},
	"priority": null,
	"restricted_roles": null
}
```

@grosser 

