### PR TITLE
Move lock to start

### DIFF
--- a/lib/kennel/importer.rb
+++ b/lib/kennel/importer.rb
@@ -26,6 +26,7 @@ module Kennel
       title_field = TITLES.detect { |f| data[f] }
       title = data.fetch(title_field)
       title.tr!(Kennel::Models::Record::LOCK, "") # avoid double lock icon
+      title.strip!
 
       # calculate or reuse kennel_id
       data[:kennel_id] =

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -161,7 +161,7 @@ module Kennel
 
         @json = {
           layout_type: layout_type,
-          title: "#{title}#{tags_as_string}#{LOCK}",
+          title: "#{LOCK} #{title}#{tags_as_string}",
           description: description,
           template_variables: render_template_variables,
           template_variable_presets: template_variable_presets,

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -58,7 +58,7 @@ module Kennel
       def as_json
         return @as_json if @as_json
         data = {
-          name: "#{name}#{LOCK}",
+          name: "#{LOCK} #{name}",
           type: type,
           query: query.strip,
           message: message.strip,

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -34,7 +34,7 @@ module Kennel
       def as_json
         return @as_json if @as_json
         data = {
-          name: "#{name}#{LOCK}",
+          name: "#{LOCK} #{name}",
           description: description,
           thresholds: thresholds,
           monitor_ids: monitor_ids,

--- a/lib/kennel/models/synthetic_test.rb
+++ b/lib/kennel/models/synthetic_test.rb
@@ -26,7 +26,7 @@ module Kennel
           type: type,
           subtype: subtype,
           options: options,
-          name: "#{name}#{LOCK}",
+          name: "#{LOCK} #{name}",
           locations: locations == :all ? LOCATIONS : locations
         }
 

--- a/test/kennel/importer_test.rb
+++ b/test/kennel/importer_test.rb
@@ -208,7 +208,7 @@ describe Kennel::Importer do
     end
 
     it "removes lock so we do not double it" do
-      response = { id: 123, name: "hello#{Kennel::Models::Record::LOCK}", options: {} }
+      response = { id: 123, name: "#{Kennel::Models::Record::LOCK} hello", options: {} }
       stub_datadog_request(:get, "monitor/123").to_return(body: response.to_json)
       code = importer.import("monitor", 123)
       code.must_include 'name: -> { "hello" }'

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -16,7 +16,7 @@ describe Kennel::Models::Dashboard do
   let(:expected_json) do
     {
       layout_type: "ordered",
-      title: "Hello🔒",
+      title: "🔒 Hello",
       description: "",
       template_variables: [],
       template_variable_presets: nil,
@@ -90,7 +90,7 @@ describe Kennel::Models::Dashboard do
 
     it "adds team tags when requested" do
       project.team.class.any_instance.expects(:tag_dashboards).returns(true)
-      dashboard.as_json[:title].must_equal "Hello (team:test_team)🔒"
+      dashboard.as_json[:title].must_equal "🔒 Hello (team:test_team)"
     end
 
     describe "definitions" do

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -23,7 +23,7 @@ describe Kennel::Models::Monitor do
   let(:id_map) { Kennel::IdMap.new }
   let(:expected_basic_json) do
     {
-      name: "Kennel::Models::Monitor\u{1F512}",
+      name: "\u{1F512} Kennel::Models::Monitor",
       type: "query alert",
       query: +"avg(last_5m) > 123.0",
       message: "@slack-foo",

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -23,7 +23,7 @@ describe Kennel::Models::Slo do
   let(:id_map) { Kennel::IdMap.new }
   let(:expected_basic_json) do
     {
-      name: "Foo\u{1F512}",
+      name: "\u{1F512} Foo",
       description: nil,
       thresholds: [],
       monitor_ids: [],

--- a/test/kennel/models/synthetic_test_test.rb
+++ b/test/kennel/models/synthetic_test_test.rb
@@ -35,7 +35,7 @@ describe Kennel::Models::SyntheticTest do
       type: "api",
       subtype: "http",
       options: {},
-      name: "foo\u{1F512}",
+      name: "\u{1F512} foo",
       locations: ["l1"]
     }
   end

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -315,7 +315,7 @@ describe Kennel::Syncer do
         expected << slo("a", "b", id: "abc")
         slos << {
           id: "abc",
-          name: "x\u{1F512}",
+          name: "\u{1F512} x",
           type: "metric",
           thresholds: [],
           tags: ["team:test_team", "service:a"],


### PR DESCRIPTION
and add a space

Datadog object names are often shown in lists, and when they are, they're usually start-aligned (i.e. for English, left-aligned). I like it when things line up. Therefore, this PR moves the padlock emoji to the start of the text (and adds a space between the padlock and the rest of the object name), so that all the padlocks line up. Because that's pleasing, and less distracting.
