### PR TITLE
pretty_inspect supports Ruby 2.7

### DIFF
--- a/lib/kennel/utils.rb
+++ b/lib/kennel/utils.rb
@@ -149,7 +149,7 @@ module Kennel
       # TODO: use awesome-print or similar, but it has too many monkey-patches
       # https://github.com/amazing-print/amazing_print/issues/36
       def pretty_inspect(object)
-        string = object.inspect
+        string = object.inspect.dup
         string.gsub!(/:([a-z_]+)=>/, "\\1: ")
         10.times do
           string.gsub!(/{(\S.*?\S)}/, "{ \\1 }") || break


### PR DESCRIPTION
I'm trying to fix this error in 2.7:

```
FrozenError: can't modify frozen String: "false"
kennel/vendor/bundle/ruby/2.7.0/gems/kennel-1.112.0/lib/kennel/utils.rb:153:in `gsub!'
kennel/kennel/vendor/bundle/ruby/2.7.0/gems/kennel-1.112.0/lib/kennel/utils.rb:153:in `pretty_inspect'
kennel/kennel/vendor/bundle/ruby/2.7.0/gems/kennel-1.112.0/lib/kennel/syncer.rb:200:in `block in print_diff'
```

This is due to a change on boolean `inspect`:

in 2.6:

```ruby
true.inspect.frozen?
=> false
```

in 2.7:
```
true.inspect.frozen?
=> true
```