### PR TITLE
Allow id-expansion in description/message

### DIFF
--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -186,6 +186,7 @@ module Kennel
       end
 
       def resolve_linked_tracking_ids!(id_map, **args)
+        super
         widgets = as_json[:widgets].flat_map { |w| [w, *w.dig(:definition, :widgets) || []] }
         widgets.each do |widget|
           next unless definition = widget[:definition]

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -125,6 +125,7 @@ module Kennel
       end
 
       def resolve_linked_tracking_ids!(id_map, **args)
+        super
         case as_json[:type]
         when "composite", "slo alert"
           type = (as_json[:type] == "composite" ? :monitor : :slo)

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -68,6 +68,7 @@ module Kennel
       end
 
       def resolve_linked_tracking_ids!(id_map, **args)
+        super
         return unless as_json[:monitor_ids] # ignore_default can remove it
         as_json[:monitor_ids] = as_json[:monitor_ids].map do |id|
           resolve(id, :monitor, id_map, **args) || id


### PR DESCRIPTION
Allow `%{TYPE:kennel_id_with_colon}` (e.g. `%{dashboard:myproject:error_budgets}`) in description/message, to expand to the datadog-id of that item.

This allows us to write code like this, in e.g. a SLO / monitor message:

```ruby
dashboard = Sre::Dashboards::ErrorBudgetExplorer.new(Sre::Project.new)
dashboard_url = "https://zendesk.datadoghq.com/dashboard/#{dashboard.id_macro}/error-budget-explorer?tpl_var_metric=#{sli.name}&tpl_var_source=#{sli.capture_source}"

"If this alarm fires, go and look at [the dashboard](#{dashboard_url})" ...
```

No tests yet.
