### PR TITLE
Allow `setting: 123` instead of `setting: -> { 123 }`

### DIFF
--- a/test/kennel/settings_as_methods_test.rb
+++ b/test/kennel/settings_as_methods_test.rb
@@ -41,9 +41,17 @@ describe Kennel::SettingsAsMethods do
       e.message.must_equal "Expected TestSetting.new options to be a Hash, got a String"
     end
 
-    it "fails nicely when given non-procs" do
-      e = assert_raises(ArgumentError) { TestSetting.new(id: 12345) }
-      e.message.must_equal "Expected TestSetting.new option :id to be Proc, for example `id: -> { 12 }`"
+    it "accepts non-procs (constructor)" do
+      item = TestSetting.new(foo: 12345)
+      item.foo.must_equal(12345)
+    end
+
+    it "accepts non-procs (defaults)" do
+      klass = Class.new(TestSetting) do
+        defaults(foo: 12345)
+      end
+      item = klass.new
+      item.foo.must_equal(12345)
     end
 
     it "stores invocation_location" do


### PR DESCRIPTION
The kennel syntax is very noisy, and frankly, odd.

Randomly picking an example from Zendesk, this PR would allow

```
        Kennel::Models::Monitor.new(
          self,
          name: -> { "AwsRdsMysqlConsulTaggerSmokeTest" },
          query: -> { "sum(last_5m):sum:aws_rds_mysql_consul_tagger_smoke_test.result{status:fail} by {environment}.as_count() > 1" },
          message: -> { "Smoke test failing in {{environment}}.\n#{super()}" },
          critical: -> { 1 },
          escalation_message: -> { "" },
          notify_audit: -> { false },
          notify_no_data: -> { false },
          timeout_h: -> { 0 },
          type: -> { "query alert" },
          kennel_id: -> { "aws_rds_mysql_consul_tagger_smoke_test_monitor" }
        )
```

to be instead expressed more cleanly and intuitively as

```
        Kennel::Models::Monitor.new(
          self,
          name: "AwsRdsMysqlConsulTaggerSmokeTest",
          query: "sum(last_5m):sum:aws_rds_mysql_consul_tagger_smoke_test.result{status:fail} by {environment}.as_count() > 1",
          message: -> { "Smoke test failing in {{environment}}.\n#{super()}" },
          critical: 1,
          escalation_message: "",
          notify_audit: false,
          notify_no_data: false,
          timeout_h: 0,
          type: "query alert",
          kennel_id: "aws_rds_mysql_consul_tagger_smoke_test_monitor"
        )
```

Note of course that procs are still allowed, so it's backwards compatible.
