### PR TITLE
Preserve source location when using non-procs

### DIFF
--- a/lib/kennel/models/project.rb
+++ b/lib/kennel/models/project.rb
@@ -11,6 +11,8 @@ module Kennel
       def self.file_location
         @file_location ||= begin
           method_in_file = instance_methods(false).first
+          return if method_in_file.nil?
+
           instance_method(method_in_file).source_location.first.sub("#{Bundler.root}/", "")
         end
       end

--- a/lib/kennel/settings_as_methods.rb
+++ b/lib/kennel/settings_as_methods.rb
@@ -4,11 +4,15 @@ module Kennel
     SETTING_OVERRIDABLE_METHODS = [].freeze
 
     AS_PROCS = ->(options) do
+      # Fragile; depends on the fact that in both locations where AS_PROCS is
+      # used, we're 2 frames away from the user code.
+      file, line, = caller(2..2).first.split(":", 3)
+
       options.transform_values do |v|
         if v.class == Proc
           v
         else
-          -> { v }
+          eval "-> { v }", nil, file, line.to_i
         end
       end
     end

--- a/test/kennel/models/project_test.rb
+++ b/test/kennel/models/project_test.rb
@@ -5,8 +5,48 @@ SingleCov.covered!
 
 describe Kennel::Models::Project do
   describe ".file_location" do
+    let(:plain_project_class) do
+      Class.new(Kennel::Models::Project) do
+        def self.to_s
+          "PlainProject" # to make debugging less confusing
+        end
+      end
+    end
+
     it "finds the file" do
       TestProject.file_location.must_equal "test/test_helper.rb"
+    end
+
+    it "cannot detect if there are no methods" do
+      Class.new(Kennel::Models::Project).file_location.must_be_nil
+    end
+
+    it "detects the file location when defaults-plain is used" do
+      project_class = plain_project_class
+      eval <<~EVAL, nil, "dir/foo.rb", 1
+        project_class.instance_eval do
+          defaults(name: 'bar')
+        end
+      EVAL
+      project_class.file_location.must_equal("dir/foo.rb")
+    end
+
+    it "detects the file location when defaults-proc is used" do
+      project_class = plain_project_class
+      eval <<~EVAL, nil, "dir/foo.rb", 1
+        project_class.instance_eval do
+          defaults(name: -> { 'bar' })
+        end
+      EVAL
+      project_class.file_location.must_equal("dir/foo.rb")
+    end
+
+    it "detects the file location when a custom method is used" do
+      project_class = plain_project_class
+      eval <<~EVAL, nil, "dir/foo.rb", 1
+        project_class.define_method(:my_method) { }
+      EVAL
+      project_class.file_location.must_equal("dir/foo.rb")
     end
   end
 


### PR DESCRIPTION
Discussion:

The "Managed by kennel" line adds the tracking id, and then the project class's `file_location`.  `file_location` in turn is worked out by picking an essentially random instance method from the class (`instance_methods(false).first`) and using a processed form of its source_location.

This was a problem for the new proc-less form because the source location of the procs was inside the Kennel codebase (see `AS_PROCS`). Furthermore, the results were unstable, because of the randomness of the chosen instance method; if it picked one which was defined _with_ a proc, everything was fine, but if it picked one using the new proc-less syntax, then the source_location and therefore file_location and therefore "Managed by kennel" line, would be wrong.
