### PR TITLE
`#parts` must return an array

### DIFF
--- a/lib/kennel/models/project.rb
+++ b/lib/kennel/models/project.rb
@@ -2,6 +2,12 @@
 module Kennel
   module Models
     class Project < Base
+      class PartsDidNotReturnAnArrayException < RuntimeError
+        def initialize(project)
+          super("Project#parts (in #{project.name} / #{project.kennel_id}) must return an array")
+        end
+      end
+
       settings :team, :parts, :tags, :mention, :name, :kennel_id
       defaults(
         tags: -> { ["service:#{kennel_id}"] + team.tags },
@@ -19,6 +25,8 @@ module Kennel
 
       def validated_parts
         all = parts
+        raise PartsDidNotReturnAnArrayException, self unless all.is_a?(Array)
+
         validate_parts(all)
         all
       end

--- a/test/kennel/models/project_test.rb
+++ b/test/kennel/models/project_test.rb
@@ -71,9 +71,9 @@ describe Kennel::Models::Project do
       bad_project = TestProject.new(parts: -> {
         Kennel::Models::Monitor.new(self)
       })
-      assert_raises(Kennel::Models::Project::PartsDidNotReturnAnArrayException) do
+      validation_error_message do
         bad_project.validated_parts
-      end
+      end.must_equal "test_project #parts must return an array of Records"
     end
   end
 end

--- a/test/kennel/models/project_test.rb
+++ b/test/kennel/models/project_test.rb
@@ -66,5 +66,14 @@ describe Kennel::Models::Project do
     it "returns parts" do
       TestProject.new.validated_parts.size.must_equal 0
     end
+
+    it "raises an error if parts did not return an array" do
+      bad_project = TestProject.new(parts: -> {
+        Kennel::Models::Monitor.new(self)
+      })
+      assert_raises(Kennel::Models::Project::PartsDidNotReturnAnArrayException) do
+        bad_project.validated_parts
+      end
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,4 +88,8 @@ Minitest::Test.class_eval do
   def assert_json_equal(a, b)
     JSON.pretty_generate(a).must_equal JSON.pretty_generate(b)
   end
+
+  def validation_error_message(&block)
+    assert_raises(Kennel::ValidationError, &block).message
+  end
 end


### PR DESCRIPTION
See also https://github.com/zendesk/kennel/pull/14227 

This is a breaking change (insofar as it breaks projects where `parts` returns a record, not an array)