### PR TITLE
eager-load causes hanging threads

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -164,6 +164,7 @@ module Kennel
       Dir.exist?("teams") && loader.push_dir("teams", namespace: Teams)
       Dir.exist?("parts") && loader.push_dir("parts")
       loader.setup
+      loader.eager_load # TODO: this should not be needed but we see hanging CI processes when it's not added
 
       # TODO: also auto-load projects and update expected path too
       ["projects"].each do |folder|


### PR DESCRIPTION
see discussion in https://github.com/grosser/kennel/pull/175
zeitwerk claims to be thread-safe, but either we use it wrong in out installation or it simply is not 🤷 
... so hotfix for now is to disable it, which will cost a bit of execution speed