### PR TITLE
Smarter update diff simpler

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -42,8 +42,8 @@ module Kennel
 
   include Kennel::Compatibility
 
-  PlanResults = Struct.new(:plan, keyword_init: true)
-  UpdateResults = Struct.new(:plan, :update, keyword_init: true)
+  PlanResult = Struct.new(:plan, keyword_init: true)
+  UpdateResult = Struct.new(:plan, :update, keyword_init: true)
 
   class Engine
     def initialize
@@ -62,7 +62,7 @@ module Kennel
 
     def plan
       the_plan = syncer.plan
-      PlanResults.new(
+      PlanResult.new(
         plan: the_plan
       )
     end
@@ -70,7 +70,7 @@ module Kennel
     def update
       the_plan = syncer.plan
       the_update = syncer.update if syncer.confirm
-      UpdateResults.new(
+      UpdateResult.new(
         plan: the_plan,
         update: the_update
       )

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -54,11 +54,6 @@ module Kennel
 
     attr_accessor :out, :err, :strict_imports
 
-    def reset
-      remove_instance_variable(:@generated)
-      remove_instance_variable(:@syncer)
-    end
-
     def generate
       out = generated
       store out if ENV["STORE"] != "false" # quicker when debugging

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -175,13 +175,21 @@ module Kennel
     end
 
     def load_all
-      @loaded_zeitwerk ||= begin
-        loader = Zeitwerk::Loader.new
-        Dir.exist?("teams") && loader.push_dir("teams", namespace: Teams)
-        Dir.exist?("parts") && loader.push_dir("parts")
-        loader.setup
-        loader.eager_load # TODO: this should not be needed but we see hanging CI processes when it's not added
-      end
+      # load_all's purpose is to "require" all the .rb files under './projects',
+      # also with reference to ./teams and ./parts. What happens if you call it
+      # more than once?
+      #
+      # For a reason yet to be investigated, Zeitwerk rejects second and subsequent calls.
+      # But even if we skip over the Zeitwerk part, the nature of 'require' is
+      # somewhat one-way: we're not providing any mechanism to *un*load things.
+      # As long as the contents of `./projects`, `./teams` and `./parts` doesn't
+      # change between calls, then simply by no-op'ing subsequent calls to `load_all`
+      # we can have `load_all` appear to be idempotent.
+      loader = Zeitwerk::Loader.new
+      Dir.exist?("teams") && loader.push_dir("teams", namespace: Teams)
+      Dir.exist?("parts") && loader.push_dir("parts")
+      loader.setup
+      loader.eager_load # TODO: this should not be needed but we see hanging CI processes when it's not added
 
       # TODO: also auto-load projects and update expected path too
       ["projects"].each do |folder|

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -42,7 +42,6 @@ module Kennel
 
   include Kennel::Compatibility
 
-  PlanResult = Struct.new(:plan, keyword_init: true)
   UpdateResult = Struct.new(:plan, :update, keyword_init: true)
 
   class Engine
@@ -61,10 +60,7 @@ module Kennel
     end
 
     def plan
-      the_plan = syncer.plan
-      PlanResult.new(
-        plan: the_plan
-      )
+      syncer.plan
     end
 
     def update

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -2,6 +2,7 @@
 module Kennel
   module Models
     class Record < Base
+      MANAGED_BY_KENNEL = ENV.fetch("MANAGED_BY_KENNEL", "Managed by kennel")
       LOCK = "\u{1F512}"
       TRACKING_FIELDS = [:message, :description].freeze
       READONLY_ATTRIBUTES = [
@@ -28,14 +29,14 @@ module Kennel
         end
 
         def parse_tracking_id(a)
-          a[self::TRACKING_FIELD].to_s[/-- Managed by kennel (#{ALLOWED_KENNEL_ID_FULL})/, 1]
+          a[self::TRACKING_FIELD].to_s[/-- #{Regexp.escape(MANAGED_BY_KENNEL)} (#{ALLOWED_KENNEL_ID_FULL})/, 1]
         end
 
         # TODO: combine with parse into a single method or a single regex
         def remove_tracking_id(a)
           value = a[self::TRACKING_FIELD]
           a[self::TRACKING_FIELD] =
-            value.dup.sub!(/\n?-- Managed by kennel .*/, "") ||
+            value.dup.sub!(/\n?-- #{Regexp.escape(MANAGED_BY_KENNEL)} .*/, "") ||
             raise("did not find tracking id in #{value}")
         end
 
@@ -92,11 +93,11 @@ module Kennel
       def add_tracking_id
         json = as_json
         if self.class.parse_tracking_id(json)
-          invalid! "remove \"-- Managed by kennel\" line it from #{self.class::TRACKING_FIELD} to copy a resource"
+          invalid! "remove \"-- #{MANAGED_BY_KENNEL}\" line it from #{self.class::TRACKING_FIELD} to copy a resource"
         end
         json[self.class::TRACKING_FIELD] =
           "#{json[self.class::TRACKING_FIELD]}\n" \
-          "-- Managed by kennel #{tracking_id} in #{project.class.file_location}, do not modify manually".lstrip
+          "-- #{MANAGED_BY_KENNEL} #{tracking_id} in #{project.class.file_location}, do not modify manually".lstrip
       end
 
       def remove_tracking_id

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -2,7 +2,22 @@
 module Kennel
   module Models
     class Record < Base
-      MANAGED_BY_KENNEL = ENV.fetch("MANAGED_BY_KENNEL", "Managed by kennel")
+      # Apart from if you just don't like the default for some reason,
+      # overriding MARKER_TEXT allows for namespacing within the same
+      # Datadog account. If you run one Kennel setup with marker text
+      # A and another with marker text B (assuming that A isn't a
+      # substring of B and vice versa), then the two Kennel setups will
+      # operate independently of each other, not trampling over each
+      # other's objects.
+      #
+      # This could be useful for allowing multiple products / projects
+      # / teams to share a Datadog account but otherwise largely
+      # operate independently of each other. In particular, it can be
+      # useful for running a "dev" or "staging" instance of Kennel
+      # in the same account as, but mostly isolated from, a "production"
+      # instance.
+      MARKER_TEXT = ENV.fetch("KENNEL_MARKER_TEXT", "Managed by kennel")
+
       LOCK = "\u{1F512}"
       TRACKING_FIELDS = [:message, :description].freeze
       READONLY_ATTRIBUTES = [
@@ -29,14 +44,14 @@ module Kennel
         end
 
         def parse_tracking_id(a)
-          a[self::TRACKING_FIELD].to_s[/-- #{Regexp.escape(MANAGED_BY_KENNEL)} (#{ALLOWED_KENNEL_ID_FULL})/, 1]
+          a[self::TRACKING_FIELD].to_s[/-- #{Regexp.escape(MARKER_TEXT)} (#{ALLOWED_KENNEL_ID_FULL})/, 1]
         end
 
         # TODO: combine with parse into a single method or a single regex
         def remove_tracking_id(a)
           value = a[self::TRACKING_FIELD]
           a[self::TRACKING_FIELD] =
-            value.dup.sub!(/\n?-- #{Regexp.escape(MANAGED_BY_KENNEL)} .*/, "") ||
+            value.dup.sub!(/\n?-- #{Regexp.escape(MARKER_TEXT)} .*/, "") ||
             raise("did not find tracking id in #{value}")
         end
 
@@ -93,11 +108,11 @@ module Kennel
       def add_tracking_id
         json = as_json
         if self.class.parse_tracking_id(json)
-          invalid! "remove \"-- #{MANAGED_BY_KENNEL}\" line it from #{self.class::TRACKING_FIELD} to copy a resource"
+          invalid! "remove \"-- #{MARKER_TEXT}\" line it from #{self.class::TRACKING_FIELD} to copy a resource"
         end
         json[self.class::TRACKING_FIELD] =
           "#{json[self.class::TRACKING_FIELD]}\n" \
-          "-- #{MANAGED_BY_KENNEL} #{tracking_id} in #{project.class.file_location}, do not modify manually".lstrip
+          "-- #{MARKER_TEXT} #{tracking_id} in #{project.class.file_location}, do not modify manually".lstrip
       end
 
       def remove_tracking_id

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -7,7 +7,7 @@ module Kennel
     DELETE_ORDER = ["dashboard", "slo", "monitor", "synthetics/tests"].freeze # dashboards references monitors + slos, slos reference monitors
     LINE_UP = "\e[1A\033[K" # go up and clear
 
-    Plan = Struct.new(:noop?, :already_ok, :create, :update, :delete, keyword_init: true)
+    Plan = Struct.new(:noop?, :no_change, :create, :update, :delete, keyword_init: true)
     Update = Struct.new(:update_log, keyword_init: true)
 
     def initialize(api, expected, project_filter: nil, tracking_id_filter: nil)
@@ -33,7 +33,7 @@ module Kennel
 
       Plan.new(
         noop?: noop?,
-        already_ok: @already_ok,
+        no_change: @no_change,
         create: @create,
         update: @update,
         delete: @delete
@@ -121,7 +121,7 @@ module Kennel
       @warnings = []
       @update = []
       @delete = []
-      @already_ok = []
+      @no_change = []
       @id_map = IdMap.new
 
       actual = Progress.progress("Downloading definitions") { download_definitions }
@@ -155,7 +155,7 @@ module Kennel
             if diff.any?
               @update << [id, e, a, diff]
             else
-              @already_ok << [id, e, a]
+              @no_change << [id, e, a]
             end
           elsif a.fetch(:tracking_id) # was previously managed
             @delete << [id, nil, a]

--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -13,8 +13,8 @@ module Kennel
         raise SystemExit.new(1), message
       end
 
-      def environment
-        @environment ||= begin
+      def load_environment
+        @load_environment ||= begin
           require "kennel"
           gem "dotenv"
           require "dotenv"
@@ -234,6 +234,6 @@ namespace :kennel do
   end
 
   task :environment do
-    Kennel::Tasks.environment
+    Kennel::Tasks.load_environment
   end
 end

--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -150,7 +150,7 @@ namespace :kennel do
 
     if ENV["FORMAT"] == "json"
       report = monitors.map do |m|
-        match = m[:message].to_s.match(/-- #{Regexp.escape(Kennel::Models::Record::MANAGED_BY_KENNEL)} (\S+:\S+) in (\S+), /) || []
+        match = m[:message].to_s.match(/-- #{Regexp.escape(Kennel::Models::Record::MARKER_TEXT)} (\S+:\S+) in (\S+), /) || []
         m.slice(:url, :name, :tags, :days_in_no_data).merge(
           kennel_tracking_id: match[1],
           kennel_source: match[2]

--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -123,7 +123,7 @@ namespace :kennel do
 
     if ENV["FORMAT"] == "json"
       report = monitors.map do |m|
-        match = m[:message].to_s.match(/-- Managed by kennel (\S+:\S+) in (\S+), /) || []
+        match = m[:message].to_s.match(/-- #{Regexp.escape(Kennel::Models::Record::MANAGED_BY_KENNEL)} (\S+:\S+) in (\S+), /) || []
         m.slice(:url, :name, :tags, :days_in_no_data).merge(
           kennel_tracking_id: match[1],
           kennel_source: match[2]

--- a/test/kennel/tasks_test.rb
+++ b/test/kennel/tasks_test.rb
@@ -3,7 +3,7 @@ require_relative "../test_helper"
 require "rake"
 require "kennel/tasks"
 
-SingleCov.covered! uncovered: 38 # TODO: reduce this
+SingleCov.covered! uncovered: 42 # TODO: reduce this
 
 describe "tasks" do
   with_env DATADOG_APP_KEY: "foo", DATADOG_API_KEY: "bar"

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -2,7 +2,7 @@
 require_relative "test_helper"
 require "tmpdir"
 
-SingleCov.covered!
+SingleCov.covered! uncovered: 2 # TODO: reduce this
 
 describe Kennel do
   def write(file, content)

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -2,7 +2,7 @@
 require_relative "test_helper"
 require "tmpdir"
 
-SingleCov.covered! uncovered: 2 # TODO: reduce this
+SingleCov.covered!
 
 describe Kennel do
   def write(file, content)
@@ -34,10 +34,6 @@ describe Kennel do
         )
       end
     RUBY
-  end
-
-  before do
-    Zeitwerk::Loader.any_instance.stubs(:setup)
   end
 
   # we need to clean up so new definitions of TempProject trigger subclass addition


### PR DESCRIPTION
Have `.plan` and `.update` return useful data structures.

Unrelated, though useful for testing: allow the `Managed by kennel` marker to be overridden.