### PR TITLE
s/environment/load_environment/

### DIFF
--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -32,7 +32,7 @@ module Kennel
       end
 
       def ci
-        environment
+        load_environment
 
         if on_default_branch? && git_push?
           Kennel.strict_imports = false


### PR DESCRIPTION
Whoops.

Stuff in `Tasks` has very poor test coverage, so this got missed.

The `ci_and_notify` implementation that Zendesk kennel has at the moment invokes `kennel:ci` and therefore hits this bug. That forthcoming `ci_and_notify` does _not_ use the `kennel:ci` task, and so actually this bug would have been avoided – or another way of saying that is, not noticed.
