### PR TITLE
Find Links: a sketch

### DIFF
--- a/lib/kennel/id_map.rb
+++ b/lib/kennel/id_map.rb
@@ -18,5 +18,10 @@ module Kennel
     def new?(type, tracking_id)
       @map[type][tracking_id] == NEW
     end
+
+    def reverse_get(type, id)
+      @inverse_map ||= @map.transform_values(&:invert)
+      @inverse_map[type][id]
+    end
   end
 end

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -135,6 +135,20 @@ module Kennel
         end
       end
 
+      def find_links
+        case as_json[:type]
+        when "composite"
+          as_json[:query].scan(/%{(.*?)}|\b([0-9]+)\b/).map do |tracking_id, datadog_id|
+            Record::IdLink.new(Monitor, tracking_id || datadog_id)
+          end
+        when "slo alert"
+          as_json[:query].scan(/%{(.*?)}|\b([0-9a-f]{32})\b/).map do |tracking_id, datadog_id|
+            Record::IdLink.new(Slo, tracking_id || datadog_id)
+          end
+        else # do nothing
+        end
+      end
+
       def validate_update!(_actuals, diffs)
         # ensure type does not change, but not if it's metric->query which is supported and used by importer.rb
         _, path, from, to = diffs.detect { |_, path, _, _| path == "type" }

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -2,6 +2,15 @@
 module Kennel
   module Models
     class Record < Base
+      class IdLink
+        def initialize(klass, id)
+          @klass = klass
+          @id = id.to_s
+        end
+
+        attr_reader :klass, :id
+      end
+
       # Apart from if you just don't like the default for some reason,
       # overriding MARKER_TEXT allows for namespacing within the same
       # Datadog account. If you run one Kennel setup with marker text
@@ -103,6 +112,9 @@ module Kennel
       end
 
       def resolve_linked_tracking_ids!(*)
+      end
+
+      def find_links
       end
 
       def add_tracking_id

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -74,6 +74,14 @@ module Kennel
         end
       end
 
+      def find_links
+        return unless ids = as_json[:monitor_ids]
+
+        ids.map do |tracking_id, datadog_id|
+          Record::IdLink.new(Monitor, tracking_id || datadog_id)
+        end
+      end
+
       def self.normalize(expected, actual)
         super
 


### PR DESCRIPTION
Once all of "actual" and "expected" is available, walk through all of "expected" looking for cross-resource references - _both tracking id and datadog id_. Get a nice data structure mapping it all.

Display some output showing all those cross-resource references. For the ones where the reference is via datadog id, classify each one as:

 * it exists and is in kennel, so we can replace it by a tracking id (TODO, bug: doesn't check if the item in question is being deleted)
 * it exists, and isn't in kennel
 * it doesn't exist

This stuff could be used to drive the "must link by tracking id" check, including with recommendations for _what_ tracking id to change it to.

It could also be used to drive `resolve_linked_tracking_ids!` – i.e. we scan once to work out where all the references are, and then use that to determine an efficient resolution order. The current method is a little bit brute-force.

Example output:

```
Links by kennel id:
dashboard account_data_deletion:account-data-deletion-slo -> slo account_data_deletion:account_data_deletion_time_slo-slo
dashboard account_data_deletion:account-data-deletion-slo -> slo account_data_deletion:account_data_deletion_time_slo_staging-slo
dashboard account_data_deletion:account-data-deletion-slo -> slo account_data_deletion:data_deletion_audits_failing_to_start_slo-slo
dashboard actor_management_service:actor-management-service-slos -> slo actor_management_service:actor-capacity-publisher-data-freshness-slo
dashboard actor_management_service:actor-management-service-slos -> slo actor_management_service:actor-capacity-bootstrap-publisher-data-freshness-slo
...

Links by datadog id:
dashboard admin_centre:admin-center-framework-channel-configuration-alert-dashboard -> monitor 20154574 can be replaced by admin_centre:acf-monitor-api-request-error-channel_configuration
dashboard admin_centre:admin-center-framework-channel-configuration-alert-dashboard -> monitor 20154576 can be replaced by admin_centre:acf-monitor-client-error-channel_configuration
dashboard agent_status_keeper:ask-agent-status-keeper-slo -> slo 9fc97bcd351451d5967e788f25741dfc exists but not in kennel
dashboard agent_status_keeper:ask-agent-status-keeper-slo -> slo 76d5c4449eff5e819281b4aafaa3984b exists but not in kennel
...
dashboard billing_otters_project:g-m-billing-otters-core-feature-slos-monitors -> slo 866eb7e3686859818f1ad1809f8420b7 can be replaced by billing_otters_project:billing-core-feature-sku-subscriptions-update-success-rate-for-spp-migration
dashboard billing_otters_project:g-m-billing-otters-core-feature-slos-monitors -> slo 233c81429575590f9276e25bdfa45e82 doesn't exist
dashboard billing_otters_project:g-m-billing-otters-core-feature-slos-monitors -> slo a8c7e0471c5a5a779a4ee41216ec1b32 doesn't exist
dashboard billing_otters_project:g-m-billing-otters-core-feature-slos-monitors -> slo 49a2dbff26155ae6822d74dad47d3583 doesn't exist
dashboard billing_otters_project:g-m-billing-otters-core-feature-slos-monitors -> slo 1d510f75ff6e5fd3b726b3022b485ecd doesn't exist
dashboard billing_otters_project:g-m-billing-otters-assisted-online-cart-subscription-page-drilldown -> slo cdef5b2ed83f55cda0c090b64a79e182 can be replaced by billing_otters_project:billing-otters-slos-api-v1-accounts-controller-show
dashboard billing_otters_project:g-m-billing-otters-assisted-online-cart-subscription-page-drilldown -> slo 6719d6f30288508fa1b9ad0e59d7aef5 can be replaced by billing_otters_project:billing-otters-slos-api-v1-account-eligibility-groups-controller-show
...
```

cc @grosser 