### PR TITLE
allow using escaped replacement style

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -264,6 +264,7 @@ module Kennel
         return if used.empty?
         used.flatten!(1)
         used.uniq!
+        used.map! { |w| w.tr("[]", "") }
 
         # TODO
         # - also match without by

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -351,6 +351,12 @@ describe Kennel::Models::Monitor do
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
         e.message.must_equal "test_project:m1 Used foo.name in the message, but can only be used with env.name.\nGroup or filter the query by foo to use it."
       end
+
+      it "passes with [escaped] query style" do
+        mon.stubs(:query).returns("avg(last_5m):avg:foo{bar.baz:foo} by {env} > 123.0")
+        mon.expects(:message).returns("{{[bar.baz].name}}")
+        mon.as_json
+      end
     end
 
     describe "with service check style queries" do


### PR DESCRIPTION
dd requires use of
```
{{[http.status_code].name}}
```
to be able to use a variable with a . in a message, so we should support it too