### PR TITLE
Syncer refactor

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -58,8 +58,10 @@ module Kennel
     attr_accessor :out, :err, :strict_imports
 
     def generate
-      parts = generated
-      parts_serializer.write(parts) if ENV["STORE"] != "false" # quicker when debugging
+      # At this point, the parts given by 'generated' has had the filter applied,
+      # and (assuming we don't call generate then plan then generate again), working_json
+      # is the "clean" form (i.e. == as_json)
+      parts_serializer.write(generated) if ENV["STORE"] != "false" # quicker when debugging
       parts
     end
 

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -116,7 +116,7 @@ module Kennel
           end
 
           # trigger json caching here so it counts into generating
-          Utils.parallel(parts, &:working_json)
+          Utils.parallel(parts, &:working_json!)
 
           parts
         end

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -6,6 +6,7 @@ require "English"
 
 require "kennel/version"
 require "kennel/compatibility"
+require "kennel/deep_freeze"
 require "kennel/utils"
 require "kennel/progress"
 require "kennel/filter"

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -116,7 +116,7 @@ module Kennel
           end
 
           # trigger json caching here so it counts into generating
-          Utils.parallel(parts, &:as_json)
+          Utils.parallel(parts, &:working_json)
 
           parts
         end

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -62,7 +62,7 @@ module Kennel
       # and (assuming we don't call generate then plan then generate again), working_json
       # is the "clean" form (i.e. == as_json)
       parts_serializer.write(generated) if ENV["STORE"] != "false" # quicker when debugging
-      parts
+      nil
     end
 
     def plan

--- a/lib/kennel/deep_freeze.rb
+++ b/lib/kennel/deep_freeze.rb
@@ -1,0 +1,28 @@
+module Kennel
+  module DeepFreeze
+    # There'll be a gem for this somewhere.
+    # This code doesn't handle cycles or other reused references.
+
+    def deep_freeze(item)
+      case item
+      when Hash
+        item.map { |k, v| [ deep_freeze(k), deep_freeze(v) ] }.to_h
+      when Array
+        item.map { |v| deep_freeze(v) }
+      else
+        item.dup.freeze
+      end.freeze
+    end
+
+    def deep_dup_thaw(value)
+      case value
+      when Array
+        value.map { |v| deep_dup_thaw(v) }
+      when Hash
+        value.map { |k, v| [ deep_dup_thaw(k), deep_dup_thaw(v) ] }.to_h
+      else
+        value.dup
+      end
+    end
+  end
+end

--- a/lib/kennel/deep_freeze.rb
+++ b/lib/kennel/deep_freeze.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kennel
   module DeepFreeze
     # There'll be a gem for this somewhere.
@@ -6,7 +8,7 @@ module Kennel
     def deep_freeze(item)
       case item
       when Hash
-        item.map { |k, v| [ deep_freeze(k), deep_freeze(v) ] }.to_h
+        item.map { |k, v| [deep_freeze(k), deep_freeze(v)] }.to_h
       when Array
         item.map { |v| deep_freeze(v) }
       else
@@ -19,7 +21,7 @@ module Kennel
       when Array
         value.map { |v| deep_dup_thaw(v) }
       when Hash
-        value.map { |k, v| [ deep_dup_thaw(k), deep_dup_thaw(v) ] }.to_h
+        value.map { |k, v| [deep_dup_thaw(k), deep_dup_thaw(v)] }.to_h
       else
         value.dup
       end

--- a/lib/kennel/models/base.rb
+++ b/lib/kennel/models/base.rb
@@ -18,7 +18,7 @@ module Kennel
       end
 
       def to_json # rubocop:disable Lint/ToJSON
-        raise NotImplementedError, "Use as_json"
+        raise NotImplementedError, "Use working_json"
       end
 
       private

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -152,7 +152,7 @@ module Kennel
         end
       end
 
-      def as_json
+      def working_json
         return @json if @json
         all_widgets = render_definitions(definitions) + widgets
         expand_q all_widgets
@@ -186,7 +186,7 @@ module Kennel
       end
 
       def resolve_linked_tracking_ids!(id_map, **args)
-        widgets = as_json[:widgets].flat_map { |w| [w, *w.dig(:definition, :widgets) || []] }
+        widgets = working_json[:widgets].flat_map { |w| [w, *w.dig(:definition, :widgets) || []] }
         widgets.each do |widget|
           next unless definition = widget[:definition]
           case definition[:type]

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -57,7 +57,6 @@ module Kennel
       )
 
       def as_json
-        return @as_json if @as_json
         data = {
           name: "#{name}#{LOCK}",
           type: type,
@@ -122,14 +121,14 @@ module Kennel
 
         validate_json(data) if validate
 
-        @as_json = data
+        data
       end
 
       def resolve_linked_tracking_ids!(id_map, **args)
-        case as_json[:type]
+        case working_json[:type]
         when "composite", "slo alert"
-          type = (as_json[:type] == "composite" ? :monitor : :slo)
-          as_json[:query] = as_json[:query].gsub(/%{(.*?)}/) do
+          type = (working_json[:type] == "composite" ? :monitor : :slo)
+          working_json[:query] = working_json[:query].gsub(/%{(.*?)}/) do
             resolve($1, type, id_map, **args) || $&
           end
         else # do nothing

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -81,7 +81,7 @@ module Kennel
       end
 
       def diff(actual)
-        expected = as_json
+        expected = working_json
         expected.delete(:id)
 
         self.class.send(:normalize, expected, actual)
@@ -106,7 +106,7 @@ module Kennel
       end
 
       def add_tracking_id
-        json = as_json
+        json = working_json
         if self.class.parse_tracking_id(json)
           invalid! "remove \"-- #{MARKER_TEXT}\" line it from #{self.class::TRACKING_FIELD} to copy a resource"
         end
@@ -116,7 +116,7 @@ module Kennel
       end
 
       def remove_tracking_id
-        self.class.remove_tracking_id(as_json)
+        self.class.remove_tracking_id(working_json)
       end
 
       def validate_update!(*)

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -2,6 +2,8 @@
 module Kennel
   module Models
     class Record < Base
+      include DeepFreeze
+
       # Apart from if you just don't like the default for some reason,
       # overriding MARKER_TEXT allows for namespacing within the same
       # Datadog account. If you run one Kennel setup with marker text
@@ -78,6 +80,15 @@ module Kennel
         raise ArgumentError, "First argument must be a project, not #{project.class}" unless project.is_a?(Project)
         @project = project
         super(*args)
+      end
+
+      def working_json
+        @working_json ||= deep_dup_thaw(as_json)
+      end
+
+      def working_json!
+        @working_json = nil
+        working_json
       end
 
       def diff(actual)

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -32,7 +32,6 @@ module Kennel
       end
 
       def as_json
-        return @as_json if @as_json
         data = {
           name: "#{name}#{LOCK}",
           description: description,
@@ -52,7 +51,7 @@ module Kennel
           data[:groups] = v
         end
 
-        @as_json = data
+        data
       end
 
       def self.api_resource
@@ -68,8 +67,8 @@ module Kennel
       end
 
       def resolve_linked_tracking_ids!(id_map, **args)
-        return unless ids = as_json[:monitor_ids] # ignore_default can remove it
-        as_json[:monitor_ids] = ids.map do |id|
+        return unless ids = working_json[:monitor_ids] # ignore_default can remove it
+        working_json[:monitor_ids] = ids.map do |id|
           resolve(id, :monitor, id_map, **args) || id
         end
       end

--- a/lib/kennel/models/synthetic_test.rb
+++ b/lib/kennel/models/synthetic_test.rb
@@ -17,7 +17,6 @@ module Kennel
       )
 
       def as_json
-        return @as_json if @as_json
         locations = locations()
         data = {
           message: message,
@@ -34,7 +33,7 @@ module Kennel
           data[:id] = v
         end
 
-        @as_json = data
+        data
       end
 
       def self.api_resource

--- a/lib/kennel/parts_serializer.rb
+++ b/lib/kennel/parts_serializer.rb
@@ -31,7 +31,7 @@ module Kennel
         used << File.dirname(path) # only 1 level of sub folders, so this is enough
         used << path
 
-        payload = part.as_json.merge(api_resource: part.class.api_resource)
+        payload = part.working_json.merge(api_resource: part.class.api_resource)
         write_file_if_necessary(path, JSON.pretty_generate(payload) << "\n")
       end
 

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -10,6 +10,8 @@ module Kennel
     Plan = Struct.new(:noop?, :no_change, :create, :update, :delete, keyword_init: true)
     Update = Struct.new(:update_log, keyword_init: true)
 
+    # Assuming we follow the normal call flow sequence, 'expected' is
+    # a filtered list of parts where working_json is "clean" (== as_json).
     def initialize(api, expected, project_filter: nil, tracking_id_filter: nil)
       @api = api
       @project_filter = project_filter

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -52,7 +52,7 @@ module Kennel
       each_resolved @create do |_, e|
         message = "#{e.class.api_resource} #{e.tracking_id}"
         Kennel.out.puts "Creating #{message}"
-        reply = @api.create e.class.api_resource, e.as_json
+        reply = @api.create e.class.api_resource, e.working_json
         cache_metadata reply, e.class
         id = reply.fetch(:id)
         update_log << [:create, e.class.api_resource, id]
@@ -63,7 +63,7 @@ module Kennel
       each_resolved @update do |id, e|
         message = "#{e.class.api_resource} #{e.tracking_id} #{e.class.url(id)}"
         Kennel.out.puts "Updating #{message}"
-        @api.update e.class.api_resource, id, e.as_json
+        @api.update e.class.api_resource, id, e.working_json
         update_log << [:update, e.class.api_resource, id]
         Kennel.out.puts "#{LINE_UP}Updated #{message}"
       end

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -139,7 +139,7 @@ module Kennel
         add_actual_to_id_map(actual) # and then override those resources that exist with their actual id
 
         filtered_actual = filter_actual(actual)
-        resolve_linked_tracking_ids! expected # resolve dependencies to avoid diff
+        resolve_linked_tracking_ids! expected # resolve dependencies to avoid diff. FIXME, untested!
 
         expected.each(&:add_tracking_id) # avoid diff with actual
 

--- a/test/kennel/deep_freeze_test.rb
+++ b/test/kennel/deep_freeze_test.rb
@@ -11,7 +11,7 @@ describe Kennel::DeepFreeze do
     end.new
   end
 
-  describe '#deep_freeze' do
+  describe "#deep_freeze" do
     it "can freeze strings" do
       input = "foo".dup
       output = target.deep_freeze(input)
@@ -21,7 +21,7 @@ describe Kennel::DeepFreeze do
     end
 
     it "can freeze hashes" do
-      input = { ['a'] => "bar".dup }
+      input = { ["a"] => "bar".dup }
       input.frozen?.must_equal(false)
       input.keys.first.frozen?.must_equal(false)
       input.values.first.frozen?.must_equal(false)
@@ -39,7 +39,7 @@ describe Kennel::DeepFreeze do
     end
 
     it "can freeze arrays" do
-      input = [ ['a'], "bar".dup ]
+      input = [["a"], "bar".dup]
       input.frozen?.must_equal(false)
       input[0].frozen?.must_equal(false)
       input[1].frozen?.must_equal(false)
@@ -57,10 +57,10 @@ describe Kennel::DeepFreeze do
     end
   end
 
-  describe '#deep_dup_thaw' do
+  describe "#deep_dup_thaw" do
     it "can deeply thaw" do
       input = {
-        ['a'.freeze].freeze => "b".freeze
+        ["a"].freeze => "b"
       }.freeze
 
       output = target.deep_dup_thaw(input)

--- a/test/kennel/deep_freeze_test.rb
+++ b/test/kennel/deep_freeze_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+SingleCov.covered!
+
+describe Kennel::DeepFreeze do
+  let(:target) do
+    Class.new do
+      include Kennel::DeepFreeze
+    end.new
+  end
+
+  describe '#deep_freeze' do
+    it "can freeze strings" do
+      input = "foo".dup
+      output = target.deep_freeze(input)
+      output.must_equal(input)
+      output.frozen?.must_equal(true)
+      input.frozen?.must_equal(false)
+    end
+
+    it "can freeze hashes" do
+      input = { ['a'] => "bar".dup }
+      input.frozen?.must_equal(false)
+      input.keys.first.frozen?.must_equal(false)
+      input.values.first.frozen?.must_equal(false)
+
+      output = target.deep_freeze(input)
+      output.must_equal(input)
+
+      output.frozen?.must_equal(true)
+      output.keys.first.frozen?.must_equal(true)
+      output.values.first.frozen?.must_equal(true)
+
+      input.frozen?.must_equal(false)
+      input.keys.first.frozen?.must_equal(false)
+      input.values.first.frozen?.must_equal(false)
+    end
+
+    it "can freeze arrays" do
+      input = [ ['a'], "bar".dup ]
+      input.frozen?.must_equal(false)
+      input[0].frozen?.must_equal(false)
+      input[1].frozen?.must_equal(false)
+
+      output = target.deep_freeze(input)
+      output.must_equal(input)
+
+      output.frozen?.must_equal(true)
+      output[0].frozen?.must_equal(true)
+      output[1].frozen?.must_equal(true)
+
+      input.frozen?.must_equal(false)
+      input[0].frozen?.must_equal(false)
+      input[1].frozen?.must_equal(false)
+    end
+  end
+
+  describe '#deep_dup_thaw' do
+    it "can deeply thaw" do
+      input = {
+        ['a'.freeze].freeze => "b".freeze
+      }.freeze
+
+      output = target.deep_dup_thaw(input)
+
+      output.frozen?.must_equal(false)
+      output.keys.first.frozen?.must_equal(false)
+      output.values.first.frozen?.must_equal(false)
+      output.keys.first.first.frozen?.must_equal(false)
+    end
+  end
+end

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -45,103 +45,103 @@ describe Kennel::Models::Dashboard do
     )
   end
 
-  describe "#as_json" do
+  describe "#working_json" do
     it "renders" do
-      dashboard.as_json.must_equal(expected_json)
+      dashboard.working_json.must_equal(expected_json)
     end
 
     it "caches" do
       d = dashboard
-      d.as_json.object_id.must_equal(d.as_json.object_id)
+      d.working_json.object_id.must_equal(d.working_json.object_id)
     end
 
     it "renders requests" do
-      dashboard_with_requests.as_json.must_equal expected_json_with_requests
+      dashboard_with_requests.working_json.must_equal expected_json_with_requests
     end
 
     it "can ignore validations" do
-      dashboard(widgets: -> { [{ definition: { "foo" => 1 } }] }, validate: -> { false }).as_json
+      dashboard(widgets: -> { [{ definition: { "foo" => 1 } }] }, validate: -> { false }).working_json
     end
 
     it "complains when datadog would created a diff by sorting template_variable_presets" do
       assert_raises Kennel::ValidationError do
-        dashboard(template_variable_presets: -> { [{ name: "B" }, { name: "A" }] }).as_json
+        dashboard(template_variable_presets: -> { [{ name: "B" }, { name: "A" }] }).working_json
       end
     end
 
     it "doesn't complain on sorted template_variable_presets" do
-      dashboard(template_variable_presets: -> { [{ name: "A" }, { name: "B" }] }).as_json
+      dashboard(template_variable_presets: -> { [{ name: "A" }, { name: "B" }] }).working_json
     end
 
     it "adds ID when given" do
-      dashboard(id: -> { "abc" }).as_json.must_equal expected_json.merge(id: "abc")
+      dashboard(id: -> { "abc" }).working_json.must_equal expected_json.merge(id: "abc")
     end
 
     it "can resolve q from metadata" do
       expected_json_with_requests[:widgets][0][:definition][:requests][0][:metadata] = [{ expression: "foo" }]
       dashboard(
         widgets: -> { [{ definition: { requests: [{ q: :metadata, display_type: "area", metadata: [{ expression: "foo" }] }], type: "timeseries", title: "bar" } }] }
-      ).as_json.must_equal(expected_json_with_requests)
+      ).working_json.must_equal(expected_json_with_requests)
     end
 
     it "does not add reflow for free" do
       expected_json[:layout_type] = "free"
       expected_json.delete(:reflow_type)
-      dashboard(layout_type: -> { "free" }).as_json.must_equal(expected_json)
+      dashboard(layout_type: -> { "free" }).working_json.must_equal(expected_json)
     end
 
     it "adds team tags when requested" do
       project.team.class.any_instance.expects(:tag_dashboards).returns(true)
-      dashboard.as_json[:title].must_equal "Hello (team:test_team)🔒"
+      dashboard.working_json[:title].must_equal "Hello (team:test_team)🔒"
     end
 
     describe "definitions" do
       it "can add definitions" do
-        dashboard(definitions: -> { [["bar", "timeseries", "area", "foo"]] }).as_json.must_equal expected_json_with_requests
+        dashboard(definitions: -> { [["bar", "timeseries", "area", "foo"]] }).working_json.must_equal expected_json_with_requests
       end
 
       it "can add toplists" do
-        json = dashboard(definitions: -> { [["bar", "toplist", nil, "foo"]] }).as_json
+        json = dashboard(definitions: -> { [["bar", "toplist", nil, "foo"]] }).working_json
         json[:widgets][0][:definition][:requests][0].must_equal q: "foo"
       end
 
       it "can add raw widgets to mix into definitions" do
-        json = dashboard(definitions: -> { [{ leave: "this" }] }).as_json
+        json = dashboard(definitions: -> { [{ leave: "this" }] }).working_json
         json[:widgets][0].must_equal leave: "this"
       end
 
       it "fails with too little args" do
         assert_raises ArgumentError do
-          dashboard(definitions: -> { [["bar", "timeseries", "area"]] }).as_json
+          dashboard(definitions: -> { [["bar", "timeseries", "area"]] }).working_json
         end
       end
 
       it "fails with many args" do
         assert_raises ArgumentError do
-          dashboard(definitions: -> { [["bar", "timeseries", "area", "foo", {}, 1]] }).as_json
+          dashboard(definitions: -> { [["bar", "timeseries", "area", "foo", {}, 1]] }).working_json
         end
       end
 
       it "fails with non-hash options" do
         assert_raises ArgumentError do
-          dashboard(definitions: -> { [["bar", "timeseries", "area", "foo", 1]] }).as_json
+          dashboard(definitions: -> { [["bar", "timeseries", "area", "foo", 1]] }).working_json
         end
       end
 
       it "fails with unknown options" do
         assert_raises ArgumentError do
-          dashboard(definitions: -> { [["bar", "timeseries", "area", "foo", { a: 1 }]] }).as_json
+          dashboard(definitions: -> { [["bar", "timeseries", "area", "foo", { a: 1 }]] }).working_json
         end
       end
     end
   end
 
   describe "#resolve_linked_tracking_ids" do
-    let(:definition) { dashboard_with_requests.as_json[:widgets][0][:definition] }
+    let(:definition) { dashboard_with_requests.working_json[:widgets][0][:definition] }
 
     def resolve(force: false)
       dashboard_with_requests.resolve_linked_tracking_ids!(id_map, force: force)
-      dashboard_with_requests.as_json[:widgets][0][:definition]
+      dashboard_with_requests.working_json[:widgets][0][:definition]
     end
 
     it "does nothing for regular widgets" do
@@ -149,7 +149,7 @@ describe Kennel::Models::Dashboard do
     end
 
     it "ignores widgets without definition" do
-      dashboard_with_requests.as_json[:widgets][0].delete :definition
+      dashboard_with_requests.working_json[:widgets][0].delete :definition
       resolve.must_be_nil
     end
 
@@ -290,7 +290,7 @@ describe Kennel::Models::Dashboard do
       json[:widgets][0][:definition][:conditional_formats] = formats
 
       dash = dashboard_with_requests
-      dash.as_json[:widgets][0][:definition][:conditional_formats] = formats.reverse
+      dash.working_json[:widgets][0][:definition][:conditional_formats] = formats.reverse
 
       dash.diff(json).must_equal []
 

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -111,6 +111,32 @@ describe Kennel::Models::Record do
     end
   end
 
+  describe "#working_json / #working_json!" do
+    let(:first_value) { "the first value" }
+    let(:json) { [first_value] }
+
+    before do
+      copy = json
+      monitor.define_singleton_method(:as_json) { copy }
+    end
+
+    it "uses as_json" do
+      monitor.working_json.must_equal(json)
+    end
+
+    it "takes a copy" do
+      monitor.working_json << 'foo'
+      monitor.working_json.must_equal [first_value, 'foo']
+      json.must_equal [first_value]
+    end
+
+    it "can be reset" do
+      monitor.working_json << 'foo'
+      monitor.working_json!.must_equal [first_value]
+      monitor.working_json.must_equal [first_value]
+    end
+  end
+
   describe "#diff" do
     # minitest defines diff, do not override it
     def diff_resource(e, a)

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -125,13 +125,13 @@ describe Kennel::Models::Record do
     end
 
     it "takes a copy" do
-      monitor.working_json << 'foo'
-      monitor.working_json.must_equal [first_value, 'foo']
+      monitor.working_json << "foo"
+      monitor.working_json.must_equal [first_value, "foo"]
       json.must_equal [first_value]
     end
 
     it "can be reset" do
-      monitor.working_json << 'foo'
+      monitor.working_json << "foo"
       monitor.working_json!.must_equal [first_value]
       monitor.working_json.must_equal [first_value]
     end

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -91,9 +91,9 @@ describe Kennel::Models::Record do
 
   describe "#add_tracking_id" do
     it "adds" do
-      monitor.as_json[:message].wont_include "kennel"
+      monitor.working_json[:message].wont_include "kennel"
       monitor.add_tracking_id
-      monitor.as_json[:message].must_include "kennel"
+      monitor.working_json[:message].must_include "kennel"
     end
 
     it "fails when it would have been added twice (user already added it by mistake)" do
@@ -104,10 +104,10 @@ describe Kennel::Models::Record do
 
   describe "#remove_tracking_id" do
     it "removes" do
-      old = monitor.as_json[:message].dup
+      old = monitor.working_json[:message].dup
       monitor.add_tracking_id
       monitor.remove_tracking_id
-      monitor.as_json[:message].must_equal old
+      monitor.working_json[:message].must_equal old
     end
   end
 
@@ -116,7 +116,7 @@ describe Kennel::Models::Record do
     def diff_resource(e, a)
       default = { tags: [] }
       b = Kennel::Models::Record.new TestProject.new
-      b.define_singleton_method(:as_json) { default.merge(e) }
+      b.define_singleton_method(:working_json) { default.merge(e) }
       b.diff(default.merge(a))
     end
 

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -62,10 +62,10 @@ describe Kennel::Models::Slo do
     end
   end
 
-  describe "#as_json" do
+  describe "#working_json" do
     it "creates a basic json" do
       assert_json_equal(
-        slo.as_json,
+        slo.working_json,
         expected_basic_json
       )
     end
@@ -73,7 +73,7 @@ describe Kennel::Models::Slo do
     it "sets query for metrics" do
       expected_basic_json[:query] = "foo"
       assert_json_equal(
-        slo(query: -> { "foo" }).as_json,
+        slo(query: -> { "foo" }).working_json,
         expected_basic_json
       )
     end
@@ -81,7 +81,7 @@ describe Kennel::Models::Slo do
     it "sets id when updating by id" do
       expected_basic_json[:id] = 123
       assert_json_equal(
-        slo(id: -> { 123 }).as_json,
+        slo(id: -> { 123 }).working_json,
         expected_basic_json
       )
     end
@@ -89,7 +89,7 @@ describe Kennel::Models::Slo do
     it "sets groups when given" do
       expected_basic_json[:groups] = ["foo"]
       assert_json_equal(
-        slo(groups: -> { ["foo"] }).as_json,
+        slo(groups: -> { ["foo"] }).working_json,
         expected_basic_json
       )
     end
@@ -99,27 +99,27 @@ describe Kennel::Models::Slo do
     it "ignores empty caused by ignore_default" do
       slo = slo(monitor_ids: -> { nil })
       slo.resolve_linked_tracking_ids!(id_map, force: false)
-      refute slo.as_json[:monitor_ids]
+      refute slo.working_json[:monitor_ids]
     end
 
     it "does nothing for hardcoded ids" do
       slo = slo(monitor_ids: -> { [123] })
       slo.resolve_linked_tracking_ids!(id_map, force: false)
-      slo.as_json[:monitor_ids].must_equal [123]
+      slo.working_json[:monitor_ids].must_equal [123]
     end
 
     it "resolves relative ids" do
       slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] })
       id_map.set("monitor", "#{project.kennel_id}:mon", 123)
       slo.resolve_linked_tracking_ids!(id_map, force: false)
-      slo.as_json[:monitor_ids].must_equal [123]
+      slo.working_json[:monitor_ids].must_equal [123]
     end
 
     it "does not resolve missing ids so they can resolve when monitor was created" do
       slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] })
       id_map.set("monitor", "#{project.kennel_id}:mon", Kennel::IdMap::NEW)
       slo.resolve_linked_tracking_ids!(id_map, force: false)
-      slo.as_json[:monitor_ids].must_equal ["test_project:mon"]
+      slo.working_json[:monitor_ids].must_equal ["test_project:mon"]
     end
 
     it "fails with typos" do

--- a/test/kennel/models/synthetic_test_test.rb
+++ b/test/kennel/models/synthetic_test_test.rb
@@ -42,27 +42,27 @@ describe Kennel::Models::SyntheticTest do
     }
   end
 
-  describe "#as_json" do
+  describe "#working_json" do
     it "builds" do
-      assert_json_equal synthetic.as_json, expected_json
+      assert_json_equal synthetic.working_json, expected_json
     end
 
     it "caches" do
       s = synthetic
       s.expects(:locations)
-      2.times { s.as_json }
+      2.times { s.working_json }
     end
 
     it "can add id" do
-      synthetic(id: -> { 123 }).as_json[:id].must_equal 123
+      synthetic(id: -> { 123 }).working_json[:id].must_equal 123
     end
 
     it "can add all locations" do
-      synthetic(locations: -> { :all }).as_json[:locations].size.must_be :>, 5
+      synthetic(locations: -> { :all }).working_json[:locations].size.must_be :>, 5
     end
 
     it "can use super" do
-      synthetic(message: -> { super() }).as_json[:message].must_equal "\n\n@slack-foo"
+      synthetic(message: -> { super() }).working_json[:message].must_equal "\n\n@slack-foo"
     end
   end
 

--- a/test/kennel/progress_test.rb
+++ b/test/kennel/progress_test.rb
@@ -6,12 +6,10 @@ SingleCov.covered!
 describe Kennel::Progress do
   capture_all
 
-  before { Kennel::Progress.stubs(:sleep) } # make things fast
-
   describe ".progress" do
     it "shows progress" do
-      result = Kennel::Progress.progress("foo") do
-        sleep 0.01 # make progress print
+      result = Kennel::Progress.progress("foo", interval: 0.01) do
+        sleep 0.1 # make progress print
         123
       end
       result.must_equal 123

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -84,15 +84,15 @@ describe Kennel do
     it "resets the working_json" do
       project = Kennel::Models::Project.new(
         team: TestTeam.new,
-        kennel_id: 'a_project',
-        parts: [],
+        kennel_id: "a_project",
+        parts: []
       ).instance_eval do
         def parts
           @parts ||= [
             Kennel::Models::Monitor.new(
               self,
               type: -> { "query alert" },
-              kennel_id: -> { 'foo' },
+              kennel_id: -> { "foo" },
               query: -> { "avg(last_5m) > \#{critical}" },
               critical: -> { 1 }
             )
@@ -105,8 +105,8 @@ describe Kennel do
       Kennel::ProjectsProvider.stubs(:new).returns(OpenStruct.new(projects: [project]))
 
       Kennel::Engine.new.generate
-      project.parts[0].working_json[:new_key] = 'whatever'
-      project.parts[0].working_json[:new_key].must_equal 'whatever'
+      project.parts[0].working_json[:new_key] = "whatever"
+      project.parts[0].working_json[:new_key].must_equal "whatever"
 
       Kennel::Engine.new.generate
       project.parts[0].working_json[:new_key].must_be_nil

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -57,7 +57,8 @@ describe Kennel do
         parts.map(&:tracking_id) == ["temp_project:foo"]
       end.once
 
-      with_env(STORE: nil) { Kennel.generate }
+      result = with_env(STORE: nil) { Kennel.generate }
+      result.must_be_nil
     end
 
     it "does not store if requested" do

--- a/test/readme_test.rb
+++ b/test/readme_test.rb
@@ -27,7 +27,7 @@ describe "Readme.md" do
 
     code_blocks.each { |block, line| eval(block, nil, readme, line) } # rubocop:disable Security/Eval
 
-    Kennel::Models::Project.recursive_subclasses.each { |p| p.new.parts.each(&:as_json) }
+    Kennel::Models::Project.recursive_subclasses.each { |p| p.new.parts.each(&:working_json) }
   end
 
   it "has language selected for all code blocks so 'working' test above is reliable" do


### PR DESCRIPTION
Including:

* adding a FIXME comment for a significant gap in testing
* instead of adding tracking_id and then removing it again, we never add it in the first place
* use accessors more

Also remove the 0.2 second minimum duration in `Progress.progress`. Speeds up the syncer tests hugely.
