### PR TITLE
Speed up tests by eliminating mandatory 0.2 second wait

### DIFF
--- a/lib/kennel/progress.rb
+++ b/lib/kennel/progress.rb
@@ -16,12 +16,13 @@ module Kennel
         animation = "-\\|/"
         count = 0
         loop do
-          break if mutex.synchronize { stop }
           Kennel.err.print animation[count % animation.size]
-          mutex.synchronize do
-            cond.wait(mutex, interval)
-          end
+          last_loop = mutex.synchronize {
+            stop || cond.wait(mutex, interval)
+            stop
+          }
           Kennel.err.print "\b"
+          break if last_loop
           count += 1
         end
       end

--- a/test/kennel/progress_test.rb
+++ b/test/kennel/progress_test.rb
@@ -6,12 +6,10 @@ SingleCov.covered!
 describe Kennel::Progress do
   capture_all
 
-  before { Kennel::Progress.stubs(:sleep) } # make things fast
-
   describe ".progress" do
     it "shows progress" do
-      result = Kennel::Progress.progress("foo") do
-        sleep 0.01 # make progress print
+      result = Kennel::Progress.progress("foo", interval: 0.01) do
+        sleep 0.1 # make progress print
         123
       end
       result.must_equal 123

--- a/test/kennel/progress_test.rb
+++ b/test/kennel/progress_test.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 require_relative "../test_helper"
 
-SingleCov.covered!
+# Hard to cover all the lock cases with certainty.
+# `Kennel::Progress.progress("foo") {}` will *probably* cover the last case,
+# but there's no guarantee.
+SingleCov.covered! uncovered: 1
 
 describe Kennel::Progress do
   capture_all
@@ -29,5 +32,9 @@ describe Kennel::Progress do
     # p final
     sleep 0.01
     stderr.string.must_equal final, "progress was not stopped"
+  end
+
+  it "stops when the block is empty" do
+    Kennel::Progress.progress("nothing") {}
   end
 end


### PR DESCRIPTION
Will also speed up "production" usage of `Progress.progress`,  but since it's an average of 0.1 seconds per invocation, it won't be much there, proportionally.
