### PR TITLE
resolve composite monitor links when importing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -406,6 +406,14 @@ https://foo.datadog.com/monitor/123
 ### Find all monitors with No-Data
 `rake kennel:nodata TAG=team:foo`
 
+### Finding the tracking id of a resource
+
+When trying to link resources together, this avoids having to go through datadog UI.
+
+```Bash
+rake kennel:tracking_id ID=123 RESOURCE=monitor
+```
+
 <!-- NOT IN template/Readme.md -->
 
 ## Development

--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -233,6 +233,17 @@ namespace :kennel do
     end
   end
 
+  desc "Resolve given id to kennel tracking-id RESOURCE= ID="
+  task tracking_id: "kennel:environment" do
+    resource = ENV.fetch("RESOURCE")
+    id = ENV.fetch("ID")
+    klass =
+      Kennel::Models::Record.subclasses.detect { |s| s.api_resource == resource } ||
+      raise("resource #{resource} not know")
+    object = Kennel.send(:api).show(resource, id)
+    Kennel.out.puts klass.parse_tracking_id(object)
+  end
+
   task :environment do
     Kennel::Tasks.load_environment
   end

--- a/template/Readme.md
+++ b/template/Readme.md
@@ -388,3 +388,11 @@ https://foo.datadog.com/monitor/123
 ### Find all monitors with No-Data
 `rake kennel:nodata TAG=team:foo`
 
+### Finding the tracking id of a resource
+
+When trying to link resources together, this avoids having to go through datadog UI.
+
+```Bash
+rake kennel:tracking_id ID=123 RESOURCE=monitor
+```
+

--- a/test/kennel/compatibility_test.rb
+++ b/test/kennel/compatibility_test.rb
@@ -19,7 +19,7 @@ describe Kennel::Compatibility do
   end
 
   it "provides private :api compatibility" do
-    with_env({ "DATADOG_APP_KEY" => "x", "DATADOG_API_KEY" => "y" }) do
+    enable_api do
       api = Kennel::Api.allocate
       Kennel::Api.expects(:new).times(1).returns(api)
 

--- a/test/kennel/importer_test.rb
+++ b/test/kennel/importer_test.rb
@@ -535,7 +535,7 @@ describe Kennel::Importer do
     end
 
     it "links composite monitors" do
-      with_env({ "DATADOG_APP_KEY" => "x", "DATADOG_API_KEY" => "y" }) do
+      enable_api do
         response = { id: 123, name: "hello", type: "composite", query: "111 && 222 && 333", options: {} }
         stub_datadog_request(:get, "monitor/123").to_return(body: response.to_json)
         missing = stub_datadog_request(:get, "monitor/111").to_return(status: 404)

--- a/test/kennel/importer_test.rb
+++ b/test/kennel/importer_test.rb
@@ -534,6 +534,30 @@ describe Kennel::Importer do
       RUBY
     end
 
+    it "links composite monitors" do
+      with_env({ "DATADOG_APP_KEY" => "x", "DATADOG_API_KEY" => "y" }) do
+        response = { id: 123, name: "hello", type: "composite", query: "111 && 222 && 333", options: {} }
+        stub_datadog_request(:get, "monitor/123").to_return(body: response.to_json)
+        missing = stub_datadog_request(:get, "monitor/111").to_return(status: 404)
+        not_kennel = stub_datadog_request(:get, "monitor/222").to_return(body: { message: "not in kennel" }.to_json)
+        from_kennel = stub_datadog_request(:get, "monitor/333").to_return(body: { message: "-- Managed by kennel foo:bar" }.to_json)
+        dash = importer.import("monitor", 123)
+        dash.must_equal <<~RUBY
+          Kennel::Models::Monitor.new(
+            self,
+            name: -> { "hello" },
+            id: -> { 123 },
+            kennel_id: -> { "hello" },
+            type: -> { "composite" },
+            query: -> { "111 && 222 && %{foo:bar}" }
+          )
+        RUBY
+        assert_requested missing
+        assert_requested not_kennel
+        assert_requested from_kennel
+      end
+    end
+
     describe "synthetic test" do
       it "import basic" do
         response = { public_id: 123, name: "hello", tags: ["foo"], locations: ["abc"] }

--- a/test/kennel/tasks_test.rb
+++ b/test/kennel/tasks_test.rb
@@ -6,7 +6,7 @@ require "kennel/tasks"
 SingleCov.covered! uncovered: 42 # TODO: reduce this
 
 describe "tasks" do
-  with_env DATADOG_APP_KEY: "foo", DATADOG_API_KEY: "bar"
+  enable_api
 
   def execute(env = {})
     with_env(env) { Rake::Task[task].execute }
@@ -216,6 +216,17 @@ describe "tasks" do
     it "fails when neither is given" do
       e = assert_raises(RuntimeError) { execute(ID: "123") }
       e.message.must_equal "Aborted Call with URL= or call with RESOURCE=dashboard or monitor or slo or synthetics/tests and ID="
+    end
+  end
+
+  describe "kennel:tracking_id" do
+    let(:task) { "kennel:tracking_id" }
+
+    it "finds tracking id" do
+      get = stub_datadog_request(:get, "monitor/123").to_return(body: { message: "-- Managed by kennel foo:bar" }.to_json)
+      execute ID: "123", RESOURCE: "monitor"
+      stdout.string.must_equal "foo:bar\n"
+      assert_requested get
     end
   end
 end

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -17,7 +17,7 @@ describe Kennel do
 
   capture_all
   in_temp_dir
-  with_env DATADOG_APP_KEY: "app", DATADOG_API_KEY: "api"
+  enable_api
 
   before do
     write "projects/simple.rb", <<~RUBY

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -89,6 +89,14 @@ Minitest::Test.class_eval do
     Marshal.load(Marshal.dump(value))
   end
 
+  def self.enable_api
+    around { |t| enable_api(&t) }
+  end
+
+  def enable_api(&block)
+    with_env("DATADOG_APP_KEY" => "x", "DATADOG_API_KEY" => "y", &block)
+  end
+
   def stub_datadog_request(method, path, extra = "")
     stub_request(method, "https://app.datadoghq.com/api/v1/#{path}?#{extra}")
   end


### PR DESCRIPTION
before raw ids and a validation failure when used:
```
  query: -> { "111 && 222 && 333" },
```

after resoled ids if they are known kennel monitors:
```
  query: -> { "%{a:b} && %{b:c} && 333" },
```

decided not to auto-add validation skips in the hope that whoever runs the import will manually fix them up

/cc @zdrve 