### PR TITLE
Make better use of Kennel.{out,err}.tty?

### DIFF
--- a/lib/kennel/github_reporter.rb
+++ b/lib/kennel/github_reporter.rb
@@ -24,7 +24,7 @@ module Kennel
     end
 
     def report(&block)
-      output = Utils.strip_shell_control(Utils.tee_output(&block).strip)
+      output = Utils.tee_output(&block).strip
     rescue StandardError
       output = "Error:\n#{$ERROR_INFO.message}"
       raise

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -42,7 +42,7 @@ module Kennel
 
     def confirm
       return false if noop?
-      return true if ENV["CI"] || !STDIN.tty?
+      return true if ENV["CI"] || !STDIN.tty? || !Kennel.err.tty?
       Utils.ask("Execute Plan ?")
     end
 

--- a/lib/kennel/utils.rb
+++ b/lib/kennel/utils.rb
@@ -42,7 +42,7 @@ module Kennel
       end
 
       def ask(question)
-        Kennel.err.printf color(:red, "#{question} -  press 'y' to continue: ")
+        Kennel.err.printf color(:red, "#{question} -  press 'y' to continue: ", force: true)
         begin
           STDIN.gets.chomp == "y"
         rescue Interrupt # do not show a backtrace if user decides to Ctrl+C here
@@ -51,12 +51,10 @@ module Kennel
         end
       end
 
-      def color(color, text)
-        "\e[#{COLORS.fetch(color)}m#{text}\e[0m"
-      end
+      def color(color, text, force: false)
+        return text unless force || Kennel.out.tty?
 
-      def strip_shell_control(text)
-        text.gsub(/\e\[\d+m(.*?)\e\[0m/, "\\1").gsub(/.#{Regexp.escape("\b")}/, "")
+        "\e[#{COLORS.fetch(color)}m#{text}\e[0m"
       end
 
       def capture_stdout

--- a/test/integration.rb
+++ b/test/integration.rb
@@ -40,11 +40,14 @@ describe "Integration" do
     # result = sh "echo y | bundle exec rake kennel:update_datadog" # Uncomment this to apply know good diff
     result = sh "bundle exec rake plan 2>&1"
     result.gsub!(/\d\.\d+s/, "0.00s")
-    result = Kennel::Utils.strip_shell_control(result)
     result.must_equal <<~TXT
+      Generating ...
       Generating ... 0.00s
+      Storing ...
       Storing ... 0.00s
+      Downloading definitions ...
       Downloading definitions ... 0.00s
+      Diffing ...
       Diffing ... 0.00s
       Plan:
       Nothing to do

--- a/test/kennel/progress_test.rb
+++ b/test/kennel/progress_test.rb
@@ -7,7 +7,8 @@ describe Kennel::Progress do
   capture_all
 
   describe ".progress" do
-    it "shows progress" do
+    it "shows progress (with tty)" do
+      Kennel.err.stubs(:tty?).returns(true)
       result = Kennel::Progress.progress("foo", interval: 0.01) do
         sleep 0.10 # make progress print multiple times
         123
@@ -15,6 +16,16 @@ describe Kennel::Progress do
       result.must_equal 123
       stderr.string.must_include "|\b/\b-\b\\\b|\b"
       stderr.string.sub(/-.*?0/, "0").gsub(/\d\.\d+/, "1.11").must_equal "foo ... 1.11s\n"
+    end
+
+    it "shows progress (without tty)" do
+      Kennel.err.stubs(:tty?).returns(false)
+      result = Kennel::Progress.progress("foo", interval: 0.01) do
+        sleep 0.10 # if there were a tty, this would make it print the spinner
+        123
+      end
+      result.must_equal 123
+      stderr.string.sub(/-.*?0/, "0").gsub(/\d\.\d+/, "1.11").must_equal "foo ...\nfoo ... 1.11s\n"
     end
 
     it "stops immediately when block finishes" do

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -237,7 +237,12 @@ describe Kennel::Syncer do
     it "shows progress" do
       Kennel::Progress.unstub(:print)
       output.must_equal "Plan:\nNothing to do\n"
-      stderr.string.gsub(/\.\.\. .*?\d\.\d+s/, "... 0.0s").must_equal "Downloading definitions ... 0.0s\nDiffing ... 0.0s\n"
+      stderr.string.gsub(/\.\.\. .*?\d\.\d+s/, "... 0.0s").must_equal <<~OUTPUT
+        Downloading definitions ...
+        Downloading definitions ... 0.0s
+        Diffing ...
+        Diffing ... 0.0s
+      OUTPUT
     end
 
     it "fails when user copy-pasted existing message with kennel id since that would lead to bad updates" do
@@ -440,6 +445,7 @@ describe Kennel::Syncer do
     before do
       expected << monitor("a", "b")
       STDIN.stubs(:tty?).returns(true)
+      Kennel.err.stubs(:tty?).returns(true)
       STDIN.expects(:gets).with { raise "unexpected STDIN.gets called" }.never
     end
 
@@ -688,8 +694,12 @@ describe Kennel::Syncer do
   end
 
   describe "#diff" do
+    before do
+      Kennel.out.stubs(:tty?).returns(false)
+    end
+
     def call(a, b)
-      syncer.send(:diff, a, b).map { |l| Kennel::Utils.strip_shell_control(l) }
+      syncer.send(:diff, a, b)
     end
 
     it "can replace" do

--- a/test/kennel/unmuted_alerts_test.rb
+++ b/test/kennel/unmuted_alerts_test.rb
@@ -45,6 +45,7 @@ describe Kennel::UnmutedAlerts do
       Kennel::UnmutedAlerts.send(:sort_groups!, monitor)
       Kennel::UnmutedAlerts.expects(:filtered_monitors).returns([monitor])
       out = Kennel::Utils.capture_stdout do
+        Kennel.out.stubs(:tty?).returns(true)
         Kennel::UnmutedAlerts.send(:print, nil, tag)
       end
       out.must_equal <<~TEXT

--- a/test/kennel/utils_test.rb
+++ b/test/kennel/utils_test.rb
@@ -49,26 +49,24 @@ describe Kennel::Utils do
   end
 
   describe ".color" do
-    it "colors" do
+    it "colors (with a tty)" do
+      Kennel.out.stubs(:tty?).returns(true)
       Kennel::Utils.color(:red, "FOO").must_equal "\e[31mFOO\e[0m"
     end
 
+    it "does not color (without a tty)" do
+      Kennel.out.stubs(:tty?).returns(false)
+      Kennel::Utils.color(:red, "FOO").must_equal "FOO"
+    end
+
+    it "colors (without a tty, but with force)" do
+      Kennel.out.stubs(:tty?).returns(false)
+      Kennel::Utils.color(:red, "FOO", force: true).must_equal "\e[31mFOO\e[0m"
+    end
+
     it "refuses unknown color" do
+      Kennel.out.stubs(:tty?).returns(true)
       assert_raises(KeyError) { Kennel::Utils.color(:sdffsd, "FOO") }
-    end
-  end
-
-  describe ".strip_shell_control" do
-    it "removes color" do
-      text = "#{Kennel::Utils.color(:red, "abc")}--#{Kennel::Utils.color(:green, "efg")}"
-      Kennel::Utils.strip_shell_control(text).must_equal "abc--efg"
-    end
-
-    it "removes control characters from progress" do
-      text = Kennel::Utils.capture_stderr { Kennel::Progress.progress("Foo") { sleep 0.01 } }
-      text.must_include "\b"
-      text.gsub!(/\d+/, "0")
-      Kennel::Utils.strip_shell_control(text).must_equal "Foo ... 0.0s\n"
     end
   end
 

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -84,6 +84,7 @@ describe Kennel do
 
   describe ".plan" do
     it "plans" do
+      stdout.stubs(:tty?).returns(true)
       Kennel::Api.any_instance.expects(:list).times(models_count).returns([])
       Kennel.plan
       stdout.string.must_include "Plan:\n\e[32mCreate monitor temp_project:foo\e[0m\n"
@@ -91,7 +92,10 @@ describe Kennel do
   end
 
   describe ".update" do
-    before { STDIN.expects(:tty?).returns(true) }
+    before do
+      STDIN.expects(:tty?).returns(true)
+      Kennel.err.stubs(:tty?).returns(true)
+    end
 
     it "update" do
       Kennel::Api.any_instance.expects(:list).times(models_count).returns([])
@@ -107,6 +111,8 @@ describe Kennel do
     it "does not update when user does not confirm" do
       Kennel::Api.any_instance.expects(:list).times(models_count).returns([])
       STDIN.expects(:gets).returns("n\n") # proceed ? ... no!
+      stdout.expects(:tty?).returns(true)
+      stderr.expects(:tty?).returns(true)
 
       Kennel.update
 


### PR DESCRIPTION
To avoid finding the odd "\\" and "/" and so on (spinner debris) when redirecting the outputs.

Also removes the need for "strip_shell_control".