### PR TITLE
Protect against cache corruption

### DIFF
--- a/lib/kennel/file_cache.rb
+++ b/lib/kennel/file_cache.rb
@@ -49,6 +49,7 @@ module Kennel
 
       Tempfile.create "kennel-file-cache", dir do |tmp|
         Marshal.dump @data, tmp
+        tmp.flush
         File.rename tmp.path, @file
       end
     end

--- a/lib/kennel/file_cache.rb
+++ b/lib/kennel/file_cache.rb
@@ -15,11 +15,13 @@ module Kennel
     end
 
     def open
-      load_data
-      expire_old_data
-      yield self
-    ensure
-      persist
+      @data = load_data || {}
+      begin
+        expire_old_data
+        yield self
+      ensure
+        persist
+      end
     end
 
     def fetch(key, key_version)
@@ -35,12 +37,9 @@ module Kennel
     private
 
     def load_data
-      @data =
-        begin
-          Marshal.load(File.read(@file)) # rubocop:disable Security/MarshalLoad
-        rescue StandardError
-          {}
-        end
+      Marshal.load(File.read(@file)) # rubocop:disable Security/MarshalLoad
+    rescue Errno::ENOENT, TypeError, ArgumentError
+      nil
     end
 
     def persist


### PR DESCRIPTION
I still occasionally see cache corruption:

```
$ with-ruby - bundle exec rake generate kennel:update_datadog PROJECT=guide-redirect-service
Generating ... 2.05s
Storing ... 0.0s
Downloading definitions ... 6.6s
Diffing ... -rake aborted!
NoMethodError: undefined method `reject!' for nil:NilClass
/Users/revans/git/github.com/grosser/kennel/lib/kennel/file_cache.rb:60:in `expire_old_data'
/Users/revans/git/github.com/grosser/kennel/lib/kennel/file_cache.rb:19:in `open'
...

$ mv tmp/cache tmp/cache.bad
$ with-ruby - bundle exec rake generate kennel:update_datadog PROJECT=guide-redirect-service
<works fine>
```

In this case, somehow a `nil` had been persisted. Not sure how, but here's a defence: 23e3842

Another form of possible corruption is partial writes. Fix: 75ff2dec0eed79f492cf8394e2f7c4ad05350e6c 
