### PR TITLE
Clean up validation

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -42,6 +42,7 @@ end
 module Kennel
   ValidationError = Class.new(RuntimeError)
   UnresolvableIdError = Class.new(RuntimeError)
+  DisallowedUpdateError = Class.new(RuntimeError)
 
   include Kennel::Compatibility
 

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -40,8 +40,8 @@ module Teams
 end
 
 module Kennel
-  class ValidationError < RuntimeError
-  end
+  ValidationError = Class.new(RuntimeError)
+  UnresolvableIdError = Class.new(RuntimeError)
 
   include Kennel::Compatibility
 

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -210,9 +210,8 @@ module Kennel
       end
 
       def validate_update!(_actuals, diffs)
-        if bad_diff = diffs.find { |diff| diff[1] == "layout_type" }
-          invalid! "Datadog does not allow update of #{bad_diff[1]} (#{bad_diff[2].inspect} -> #{bad_diff[3].inspect})"
-        end
+        _, path, from, to = diffs.find { |diff| diff[1] == "layout_type" }
+        invalid_update!(path, from, to) if path
       end
 
       private

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -140,7 +140,7 @@ module Kennel
         # ensure type does not change, but not if it's metric->query which is supported and used by importer.rb
         _, path, from, to = diffs.detect { |_, path, _, _| path == "type" }
         if path && !(from == "metric alert" && to == "query alert")
-          invalid! "Datadog does not allow update of #{path} (#{from.inspect} -> #{to.inspect})"
+          invalid_update!(path, from, to)
         end
       end
 

--- a/lib/kennel/models/project.rb
+++ b/lib/kennel/models/project.rb
@@ -20,7 +20,7 @@ module Kennel
       def validated_parts
         all = parts
         unless all.is_a?(Array) && all.all? { |part| part.is_a?(Record) }
-          invalid! "#parts must return an array of Records"
+          raise "Project #{kennel_id} #parts must return an array of Records"
         end
 
         validate_parts(all)
@@ -28,11 +28,6 @@ module Kennel
       end
 
       private
-
-      # let users know which project/resource failed when something happens during diffing where the backtrace is hidden
-      def invalid!(message)
-        raise ValidationError, "#{kennel_id} #{message}"
-      end
 
       # hook for users to add custom validations via `prepend`
       def validate_parts(parts)

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -136,17 +136,21 @@ module Kennel
       def resolve_link(tracking_id, type, id_map, force:)
         if id_map.new?(type.to_s, tracking_id)
           if force
-            invalid!(
-              "#{type} #{tracking_id} was referenced but is also created by the current run.\n" \
-              "It could not be created because of a circular dependency, try creating only some of the resources"
-            )
+            raise UnresolvableIdError, <<~MESSAGE
+              #{self.tracking_id} #{type} #{tracking_id} was referenced but is also created by the current run.
+              It could not be created because of a circular dependency. Try creating only some of the resources.
+            MESSAGE
           else
             nil # will be re-resolved after the linked object was created
           end
         elsif id = id_map.get(type.to_s, tracking_id)
           id
         else
-          invalid! "Unable to find #{type} #{tracking_id} (does not exist and is not being created by the current run)"
+          raise UnresolvableIdError, <<~MESSAGE
+            #{self.tracking_id} Unable to find #{type} #{tracking_id}
+            This is either because it doesn't exist, and isn't being created by the current run;
+            or it does exist, but is being deleted.
+          MESSAGE
         end
       end
 

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -133,21 +133,21 @@ module Kennel
         id.is_a?(String) && id.include?(":")
       end
 
-      def resolve_link(tracking_id, type, id_map, force:)
-        if id_map.new?(type.to_s, tracking_id)
+      def resolve_link(sought_tracking_id, sought_type, id_map, force:)
+        if id_map.new?(sought_type.to_s, sought_tracking_id)
           if force
             raise UnresolvableIdError, <<~MESSAGE
-              #{self.tracking_id} #{type} #{tracking_id} was referenced but is also created by the current run.
+              #{tracking_id} #{sought_type} #{sought_tracking_id} was referenced but is also created by the current run.
               It could not be created because of a circular dependency. Try creating only some of the resources.
             MESSAGE
           else
             nil # will be re-resolved after the linked object was created
           end
-        elsif id = id_map.get(type.to_s, tracking_id)
+        elsif id = id_map.get(sought_type.to_s, sought_tracking_id)
           id
         else
           raise UnresolvableIdError, <<~MESSAGE
-            #{self.tracking_id} Unable to find #{type} #{tracking_id}
+            #{tracking_id} Unable to find #{sought_type} #{sought_tracking_id}
             This is either because it doesn't exist, and isn't being created by the current run;
             or it does exist, but is being deleted.
           MESSAGE

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -119,7 +119,12 @@ module Kennel
         self.class.remove_tracking_id(as_json)
       end
 
+      # Can raise DisallowedUpdateError
       def validate_update!(*)
+      end
+
+      def invalid_update!(field, old_value, new_value)
+        raise DisallowedUpdateError, "#{tracking_id} Datadog does not allow update of #{field} (#{old_value.inspect} -> #{new_value.inspect})"
       end
 
       private

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -104,11 +104,11 @@ module Kennel
     def resolved?(e)
       assert_resolved e
       true
-    rescue ValidationError
+    rescue UnresolvableIdError
       false
     end
 
-    # raises ValidationError when not resolved
+    # raises UnresolvableIdError when not resolved
     def assert_resolved(e)
       resolve_linked_tracking_ids! [e], force: true
     end

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -370,7 +370,7 @@ describe Kennel::Models::Dashboard do
     end
 
     it "disallows update of layout_type" do
-      e = assert_raises Kennel::ValidationError do
+      e = assert_raises Kennel::DisallowedUpdateError do
         dashboard.validate_update!(nil, [["~", "layout_type", "foo", "bar"]])
       end
       e.message.must_match(/datadog.*allow.*layout_type/i)

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -176,7 +176,7 @@ describe Kennel::Models::Dashboard do
       it "fail hard when id is still missing after dependent monitors were created by syncer" do
         definition[:monitor_ids] = ["missing:the_id"]
         id_map.set("monitor", "missing:the_id", Kennel::IdMap::NEW)
-        e = assert_raises Kennel::ValidationError do
+        e = assert_raises Kennel::UnresolvableIdError do
           resolve(force: true)
         end
         e.message.must_include "circular dependency"

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -434,7 +434,7 @@ describe Kennel::Models::Monitor do
       end
 
       it "fails when matching monitor is missing" do
-        e = assert_raises Kennel::ValidationError do
+        e = assert_raises Kennel::UnresolvableIdError do
           mon.resolve_linked_tracking_ids!(id_map, force: false)
         end
         e.message.must_include "test_project:m1 Unable to find monitor foo:mon_a"
@@ -462,7 +462,7 @@ describe Kennel::Models::Monitor do
       end
 
       it "fails when matching monitor is missing" do
-        e = assert_raises Kennel::ValidationError do
+        e = assert_raises Kennel::UnresolvableIdError do
           mon.resolve_linked_tracking_ids!(id_map, force: false)
         end
         e.message.must_include "test_project:m1 Unable to find slo foo:slo_a"

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -559,7 +559,7 @@ describe Kennel::Models::Monitor do
     end
 
     it "disallows update of type" do
-      e = assert_raises Kennel::ValidationError do
+      e = assert_raises Kennel::DisallowedUpdateError do
         monitor.validate_update!(nil, [["~", "type", "foo", "bar"]])
       end
       e.message.must_match(/datadog.*allow.*type/i)

--- a/test/kennel/models/project_test.rb
+++ b/test/kennel/models/project_test.rb
@@ -73,9 +73,8 @@ describe Kennel::Models::Project do
       bad_project = TestProject.new(parts: -> {
         Kennel::Models::Monitor.new(self)
       })
-      validation_error_message do
-        bad_project.validated_parts
-      end.must_equal "test_project #parts must return an array of Records"
+      assert_raises(RuntimeError) { bad_project.validated_parts } \
+        .message.must_equal "Project test_project #parts must return an array of Records"
     end
   end
 end

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -74,7 +74,7 @@ describe Kennel::Models::Record do
 
     it "fails when forcing resolve because of a circular dependency" do
       id_map.set("monitor", "foo:bar", Kennel::IdMap::NEW)
-      e = assert_raises Kennel::ValidationError do
+      e = assert_raises Kennel::UnresolvableIdError do
         base.send(:resolve, "foo:bar", :monitor, id_map, force: true)
       end
       e.message.must_include "circular dependency"
@@ -82,7 +82,7 @@ describe Kennel::Models::Record do
 
     it "fails when trying to resolve but it is unresolvable" do
       id_map.set("monitor", "foo:bar", 1)
-      e = assert_raises Kennel::ValidationError do
+      e = assert_raises Kennel::UnresolvableIdError do
         base.send(:resolve, "foo:xyz", :monitor, id_map, force: false)
       end
       e.message.must_include "test_project:test Unable to find monitor foo:xyz"

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -111,6 +111,13 @@ describe Kennel::Models::Record do
     end
   end
 
+  describe "#invalid_update!" do
+    it "raises the right error" do
+      error = assert_raises(Kennel::DisallowedUpdateError) { monitor.invalid_update!(:foo, "bar", "baz") }
+      error.message.must_equal("#{monitor.tracking_id} Datadog does not allow update of foo (\"bar\" -> \"baz\")")
+    end
+  end
+
   describe "#diff" do
     # minitest defines diff, do not override it
     def diff_resource(e, a)

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -124,7 +124,7 @@ describe Kennel::Models::Slo do
 
     it "fails with typos" do
       slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] })
-      assert_raises Kennel::ValidationError do
+      assert_raises Kennel::UnresolvableIdError do
         slo.resolve_linked_tracking_ids!(id_map, force: false)
       end
     end

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -555,19 +555,19 @@ describe Kennel::Syncer do
       monitor2 = monitor("a", "b", query: "%{a:a}", type: "composite")
       expected << monitor1
       expected << monitor2
-      assert_raises(Kennel::ValidationError) { output }.message.must_include "circular dependency"
+      assert_raises(Kennel::UnresolvableIdError) { output }.message.must_include "circular dependency"
     end
 
     it "fails on missing dependencies" do
       expected << monitor("a", "a", query: "%{a:nope}", type: "composite")
-      assert_raises(Kennel::ValidationError) { output }.message.must_include "Unable to find"
+      assert_raises(Kennel::UnresolvableIdError) { output }.message.must_include "Unable to find"
     end
 
     it "fails on to-be-deleted dependencies" do
       monitors << monitor_api_response("a", "b", id: 456)
       slo = slo("a", "c", monitor_ids: ["a:b"])
       expected << slo
-      assert_raises(Kennel::ValidationError) { output }.message.must_include "Unable to find"
+      assert_raises(Kennel::UnresolvableIdError) { output }.message.must_include "Unable to find"
     end
 
     describe "with project_filter" do


### PR DESCRIPTION
Simple enough refactor for now, but this is leading to something bigger.

What *this* PR achieves is to have `ValidationError` refer solely to the type of error which one can get from the question: "Is this record, without visibility of any other records, and without visibility of Datadog, valid?".

Also minor rewording of the error messages of what is now UnresolvableIdError.

What this is hopefully leading to (later PRs):

  * make the record validation more consistent (for example, it makes no sense that the check in `OptionalValidations` applies to only two of the record types)
  * move `validate_json if validate` to outside of `#as_json` (it should be applied to _the result of_ `as_json`)
  * Give each kind of validation error a tag (e.g. `:no_data_timeframe_too_small`); deprecate `validate: false` (which suppresses _all_ validations for that record), and replace it by a more fine-grained mechism, `skip_validations: [ :no_data_timeframe_too_small ]`. 