### PR TITLE
Make validation more consistent

### DIFF
--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -3,7 +3,6 @@ module Kennel
   module Models
     class Dashboard < Record
       include TemplateVariables
-      include OptionalValidations
 
       READONLY_ATTRIBUTES = superclass::READONLY_ATTRIBUTES + [
         :author_handle, :author_name, :modified_at, :deleted_at, :url, :is_read_only, :notify_list, :restricted_roles
@@ -167,8 +166,6 @@ module Kennel
         )
 
         json[:reflow_type] = reflow_type if reflow_type # setting nil breaks create with "ordered"
-
-        validate_json(json) if validate
 
         json
       end

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -87,8 +87,7 @@ module Kennel
         tags: -> do # not inherited by default to make onboarding to using dashboard tags simple
           team = project.team
           team.tag_dashboards ? team.tags : []
-        end,
-        id: -> { nil }
+        end
       )
 
       class << self

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -152,29 +152,26 @@ module Kennel
         end
       end
 
-      def as_json
-        return @json if @json
+      def build_json
         all_widgets = render_definitions(definitions) + widgets
         expand_q all_widgets
         tags = tags()
         tags_as_string = (tags.empty? ? "" : " (#{tags.join(" ")})")
 
-        @json = {
+        json = super.merge(
           layout_type: layout_type,
           title: "#{title}#{tags_as_string}#{LOCK}",
           description: description,
           template_variables: render_template_variables,
           template_variable_presets: template_variable_presets,
           widgets: all_widgets
-        }
+        )
 
-        @json[:reflow_type] = reflow_type if reflow_type # setting nil breaks create with "ordered"
+        json[:reflow_type] = reflow_type if reflow_type # setting nil breaks create with "ordered"
 
-        @json[:id] = id if id
+        validate_json(json) if validate
 
-        validate_json(@json) if validate
-
-        @json
+        json
       end
 
       def self.url(id)

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -56,9 +56,8 @@ module Kennel
         priority: -> { MONITOR_DEFAULTS.fetch(:priority) }
       )
 
-      def as_json
-        return @as_json if @as_json
-        data = {
+      def build_json
+        data = super.merge(
           name: "#{name}#{LOCK}",
           type: type,
           query: query.strip,
@@ -79,9 +78,7 @@ module Kennel
             locked: false, # setting this to true prevents any edit and breaks updates when using replace workflow
             renotify_interval: renotify_interval || 0
           }
-        }
-
-        data[:id] = id if id
+        )
 
         options = data[:options]
         if data.fetch(:type) != "composite"
@@ -122,7 +119,7 @@ module Kennel
 
         validate_json(data) if validate
 
-        @as_json = data
+        data
       end
 
       def resolve_linked_tracking_ids!(id_map, **args)

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -41,7 +41,6 @@ module Kennel
         renotify_interval: -> { project.team.renotify_interval },
         warning: -> { nil },
         ok: -> { nil },
-        id: -> { nil },
         notify_no_data: -> { true }, # datadog sets this to false by default, but true is the safer
         no_data_timeframe: -> { 60 },
         notify_audit: -> { MONITOR_OPTION_DEFAULTS.fetch(:notify_audit) },

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -2,8 +2,6 @@
 module Kennel
   module Models
     class Monitor < Record
-      include OptionalValidations
-
       RENOTIFY_INTERVALS = [0, 10, 20, 30, 40, 50, 60, 90, 120, 180, 240, 300, 360, 720, 1440].freeze # minutes
       OPTIONAL_SERVICE_CHECK_THRESHOLDS = [:ok, :warning].freeze
       READONLY_ATTRIBUTES = superclass::READONLY_ATTRIBUTES + [
@@ -115,8 +113,6 @@ module Kennel
           statuses << "warn" if options.dig(:thresholds, :warning)
           options[:renotify_statuses] = statuses
         end
-
-        validate_json(data) if validate
 
         data
       end

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -30,6 +30,8 @@ module Kennel
 
       settings :id, :kennel_id
 
+      defaults(id: nil)
+
       class << self
         def parse_any_url(url)
           subclasses.detect do |s|

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -132,6 +132,7 @@ module Kennel
       def as_json
         @as_json ||= begin
                        json = build_json
+                       (id = json.delete(:id)) && json[:id] = id
                        validate_json(json) if validate
                        json
                      end

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -119,6 +119,16 @@ module Kennel
         self.class.remove_tracking_id(as_json)
       end
 
+      def build_json
+        {
+          id: id
+        }.compact
+      end
+
+      def as_json
+        @as_json ||= build_json
+      end
+
       # Can raise DisallowedUpdateError
       def validate_update!(*)
       end

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -100,7 +100,7 @@ module Kennel
         @tracking_id ||= begin
           id = "#{project.kennel_id}:#{kennel_id}"
           unless id.match?(ALLOWED_KENNEL_ID_REGEX) # <-> parse_tracking_id
-            raise ValidationError, "#{id} must match #{ALLOWED_KENNEL_ID_REGEX}"
+            raise "#{id} must match #{ALLOWED_KENNEL_ID_REGEX}"
           end
           id
         end
@@ -112,7 +112,7 @@ module Kennel
       def add_tracking_id
         json = as_json
         if self.class.parse_tracking_id(json)
-          invalid! "remove \"-- #{MARKER_TEXT}\" line it from #{self.class::TRACKING_FIELD} to copy a resource"
+          raise "#{tracking_id} Remove \"-- #{MARKER_TEXT}\" line from #{self.class::TRACKING_FIELD} to copy a resource"
         end
         json[self.class::TRACKING_FIELD] =
           "#{json[self.class::TRACKING_FIELD]}\n" \

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -2,6 +2,8 @@
 module Kennel
   module Models
     class Record < Base
+      include OptionalValidations
+
       # Apart from if you just don't like the default for some reason,
       # overriding MARKER_TEXT allows for namespacing within the same
       # Datadog account. If you run one Kennel setup with marker text
@@ -128,7 +130,11 @@ module Kennel
       end
 
       def as_json
-        @as_json ||= build_json
+        @as_json ||= begin
+                       json = build_json
+                       validate_json(json) if validate
+                       json
+                     end
       end
 
       # Can raise DisallowedUpdateError

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -31,28 +31,25 @@ module Kennel
         end
       end
 
-      def as_json
-        return @as_json if @as_json
-        data = {
+      def build_json
+        data = super.merge(
           name: "#{name}#{LOCK}",
           description: description,
           thresholds: thresholds,
           monitor_ids: monitor_ids,
           tags: tags.uniq,
           type: type
-        }
+        )
 
         if v = query
           data[:query] = v
         end
-        if v = id
-          data[:id] = v
-        end
+
         if v = groups
           data[:groups] = v
         end
 
-        @as_json = data
+        data
       end
 
       def self.api_resource

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -23,13 +23,6 @@ module Kennel
         groups: -> { DEFAULTS.fetch(:groups) }
       )
 
-      def initialize(*)
-        super
-        if thresholds.any? { |t| t[:warning] && t[:warning].to_f <= t[:critical].to_f }
-          raise ValidationError, "Threshold warning must be greater-than critical value"
-        end
-      end
-
       def build_json
         data = super.merge(
           name: "#{name}#{LOCK}",
@@ -84,6 +77,16 @@ module Kennel
         actual[:tags].sort!
 
         ignore_default(expected, actual, DEFAULTS)
+      end
+
+      private
+
+      def validate_json(data)
+        super
+
+        if data[:thresholds].any? { |t| t[:warning] && t[:warning].to_f <= t[:critical].to_f }
+          invalid! "Threshold warning must be greater-than critical value"
+        end
       end
     end
   end

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -15,7 +15,6 @@ module Kennel
       settings :type, :description, :thresholds, :query, :tags, :monitor_ids, :monitor_tags, :name, :groups
 
       defaults(
-        id: -> { nil },
         tags: -> { @project.tags },
         query: -> { DEFAULTS.fetch(:query) },
         description: -> { DEFAULTS.fetch(:description) },

--- a/lib/kennel/models/synthetic_test.rb
+++ b/lib/kennel/models/synthetic_test.rb
@@ -16,10 +16,10 @@ module Kennel
         message: -> { "\n\n#{project.mention}" }
       )
 
-      def as_json
-        return @as_json if @as_json
+      def build_json
         locations = locations()
-        data = {
+
+        super.merge(
           message: message,
           tags: tags,
           config: config,
@@ -28,13 +28,7 @@ module Kennel
           options: options,
           name: "#{name}#{LOCK}",
           locations: locations == :all ? LOCATIONS : locations
-        }
-
-        if v = id
-          data[:id] = v
-        end
-
-        @as_json = data
+        )
       end
 
       def self.api_resource

--- a/lib/kennel/models/synthetic_test.rb
+++ b/lib/kennel/models/synthetic_test.rb
@@ -11,7 +11,6 @@ module Kennel
       settings :tags, :config, :message, :subtype, :type, :name, :locations, :options
 
       defaults(
-        id: -> { nil },
         tags: -> { @project.tags },
         message: -> { "\n\n#{project.mention}" }
       )

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -98,7 +98,7 @@ describe Kennel::Models::Record do
 
     it "fails when it would have been added twice (user already added it by mistake)" do
       monitor.add_tracking_id
-      assert_raises(Kennel::ValidationError) { monitor.add_tracking_id }
+      assert_raises(RuntimeError) { monitor.add_tracking_id }.message.must_include("to copy a resource")
     end
   end
 
@@ -170,7 +170,7 @@ describe Kennel::Models::Record do
         "hey ho"
       end
       base = TestRecord.new project
-      assert_raises(Kennel::ValidationError) { base.tracking_id }
+      assert_raises(RuntimeError) { base.tracking_id }
     end
   end
 

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -249,7 +249,7 @@ describe Kennel::Syncer do
       expected << monitor("a", "b", id: 234, foo: "bar", message: "foo\n-- Managed by kennel foo:bar in foo.rb")
       monitors << monitor_api_response("a", "b", id: 234)
       assert_raises(RuntimeError) { output }.message.must_equal(
-        "a:b remove \"-- Managed by kennel\" line it from message to copy a resource"
+        "a:b Remove \"-- Managed by kennel\" line from message to copy a resource"
       )
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -101,8 +101,21 @@ Minitest::Test.class_eval do
     stub_request(method, "https://app.datadoghq.com/api/v1/#{path}?#{extra}")
   end
 
+  def with_sorted_hash_keys(value)
+    case value
+    when Hash
+      value.entries.sort_by(&:first).to_h.transform_values { |v| with_sorted_hash_keys(v) }
+    when Array
+      value.map { |v| with_sorted_hash_keys(v) }
+    else
+      value
+    end
+  end
+
   # generate readables diffs when things are not equal
   def assert_json_equal(a, b)
+    a = with_sorted_hash_keys(a)
+    b = with_sorted_hash_keys(b)
     JSON.pretty_generate(a).must_equal JSON.pretty_generate(b)
   end
 


### PR DESCRIPTION
Follow-up to #210.

 * make the record validation more consistent (for example, it makes no sense that the check in OptionalValidations applies to only two of the record types)
 * move validate_json if validate to outside of #as_json (it should be applied to the result of as_json)
 * use `ValidationError` exclusively for errors from `#validate_json`

**Note that this is a breaking change**. Any override of `as_json` should be changed to `build_json`, and any memoization in those overrides should be removed.

Still to follow in a later PR:

* Give each kind of validation error a tag (e.g. `:no_data_timeframe_too_small`); deprecate `validate: false` (which suppresses _all_ validations for that record), and replace it by a more fine-grained mechanism, e.g. `skip_validations: [ :no_data_timeframe_too_small ]`
