### PR TITLE
Validation error tagging

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -40,7 +40,16 @@ module Teams
 end
 
 module Kennel
-  ValidationError = Class.new(RuntimeError)
+  class ValidationError < RuntimeError
+    def initialize(part, tag, message)
+      @part = part
+      @tag = tag
+      super(message)
+    end
+
+    attr_reader :part, :tag
+  end
+
   UnresolvableIdError = Class.new(RuntimeError)
   DisallowedUpdateError = Class.new(RuntimeError)
 

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -43,9 +43,9 @@ module Kennel
   class ValidationError < RuntimeError
     def initialize(part, tag, message)
       @part = part
-      @tag = tag
+      @tag = tag || "[unskippable]"
       @base_message = message # for testing
-      super("#{part.tracking_id} E: #{tag}: #{message}")
+      super("#{part.tracking_id} E: #{@tag}: #{message}")
     end
 
     attr_reader :part, :tag, :base_message

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -44,10 +44,11 @@ module Kennel
     def initialize(part, tag, message)
       @part = part
       @tag = tag
-      super(message)
+      @base_message = message # for testing
+      super("#{part.tracking_id} E: #{tag}: #{message}")
     end
 
-    attr_reader :part, :tag
+    attr_reader :part, :tag, :base_message
   end
 
   UnresolvableIdError = Class.new(RuntimeError)

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -230,7 +230,7 @@ module Kennel
 
         # Avoid diff from datadog presets sorting.
         presets = data[:template_variable_presets]
-        invalid! :xxx1, "template_variable_presets must be sorted by name" if presets && presets != presets.sort_by { |p| p[:name] }
+        invalid! :template_variable_presets_must_be_sorted, "template_variable_presets must be sorted by name" if presets && presets != presets.sort_by { |p| p[:name] }
       end
 
       def render_definitions(definitions)

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -230,7 +230,7 @@ module Kennel
 
         # Avoid diff from datadog presets sorting.
         presets = data[:template_variable_presets]
-        invalid! "template_variable_presets must be sorted by name" if presets && presets != presets.sort_by { |p| p[:name] }
+        invalid! :xxx1, "template_variable_presets must be sorted by name" if presets && presets != presets.sort_by { |p| p[:name] }
       end
 
       def render_definitions(definitions)

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -205,26 +205,26 @@ module Kennel
         super
 
         if data[:name]&.start_with?(" ")
-          invalid! :xxx2, "name cannot start with a space"
+          invalid! :name_must_not_start_with_whitespace, "name cannot start with a space"
         end
 
         type = data.fetch(:type)
 
         # do not allow deprecated type that will be coverted by datadog and then produce a diff
         if type == "metric alert"
-          invalid! :xxx3, "type 'metric alert' is deprecated, please set to a different type (e.g. 'query alert')"
+          invalid! :metric_alert_is_deprecated, "type 'metric alert' is deprecated, please set to a different type (e.g. 'query alert')"
         end
 
         # verify query includes critical value
         if query_value = data.fetch(:query)[/\s*[<>]=?\s*(\d+(\.\d+)?)\s*$/, 1]
           if Float(query_value) != Float(data.dig(:options, :thresholds, :critical))
-            invalid! :xxx4, "critical and value used in query must match"
+            invalid! :query_must_compare_against_critical, "critical and value used in query must match"
           end
         end
 
         # verify renotify interval is valid
         unless RENOTIFY_INTERVALS.include? data.dig(:options, :renotify_interval)
-          invalid! :xxx5, "renotify_interval must be one of #{RENOTIFY_INTERVALS.join(", ")}"
+          invalid! :renotify_interval_must_be_valid, "renotify_interval must be one of #{RENOTIFY_INTERVALS.join(", ")}"
         end
 
         if ["query alert", "service check"].include?(type) # TODO: most likely more types need this
@@ -234,15 +234,15 @@ module Kennel
         validate_using_links(data)
 
         if type == "service check" && !data[:query].to_s.include?(".by(")
-          invalid! :xxx6, "query must include a .by() at least .by(\"*\")"
+          invalid! :service_check_query_must_include_by, "query must include a .by() at least .by(\"*\")"
         end
 
         unless ALLOWED_PRIORITY_CLASSES.include?(priority.class)
-          invalid! :xxx7, "priority needs to be an Integer"
+          invalid! :priority_must_be_valid, "priority needs to be an Integer"
         end
 
         if data.dig(:options, :timeout_h)&.> 24
-          invalid! :xxx8, "timeout_h must be <= 24"
+          invalid! :timeout_h_must_be_valid, "timeout_h must be <= 24"
         end
       end
 
@@ -277,7 +277,7 @@ module Kennel
         forbidden = used - allowed
         return if forbidden.empty?
 
-        invalid! :xxx9, <<~MSG.rstrip
+        invalid! :message_must_only_use_valid_variables, <<~MSG.rstrip
           Used #{forbidden.join(", ")} in the message, but can only be used with #{allowed.join(", ")}.
           Group or filter the query by #{forbidden.map { |f| f.sub(".name", "") }.join(", ")} to use it.
         MSG
@@ -289,7 +289,7 @@ module Kennel
           ids = data[:query].tr("-", "_").scan(/\b\d+\b/)
           ids.reject! { |id| ALLOWED_UNLINKED.include?([tracking_id, id]) }
           if ids.any?
-            invalid! :xxx10, <<~MSG.rstrip
+            invalid! :composite_monitor_must_link_via_tracking_ids, <<~MSG.rstrip
               Used #{ids} in the query, but should only use links in the form of %{<project id>:<monitor id>}
               If that is not possible, add `validate_using_links: ->(*){} # linked monitors are not in kennel
             MSG

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -180,7 +180,7 @@ module Kennel
 
       # let users know which project/resource failed when something happens during diffing where the backtrace is hidden
       def invalid!(message)
-        raise ValidationError, "#{tracking_id} #{message}"
+        raise ValidationError.new(self, :xxx, "#{tracking_id} #{message}")
       end
 
       def raise_with_location(error, message)

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -179,8 +179,8 @@ module Kennel
       end
 
       # let users know which project/resource failed when something happens during diffing where the backtrace is hidden
-      def invalid!(message)
-        raise ValidationError.new(self, :xxx, "#{tracking_id} #{message}")
+      def invalid!(tag, message)
+        raise ValidationError.new(self, tag, "#{tracking_id} #{message}")
       end
 
       def raise_with_location(error, message)

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -180,7 +180,7 @@ module Kennel
 
       # let users know which project/resource failed when something happens during diffing where the backtrace is hidden
       def invalid!(tag, message)
-        raise ValidationError.new(self, tag, "#{tracking_id} #{message}")
+        raise ValidationError.new(self, tag, message)
       end
 
       def raise_with_location(error, message)

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -85,7 +85,7 @@ module Kennel
         super
 
         if data[:thresholds].any? { |t| t[:warning] && t[:warning].to_f <= t[:critical].to_f }
-          invalid! :xxx11, "Threshold warning must be greater-than critical value"
+          invalid! :slo_threshold_warning_must_be_gt_critical, "Threshold warning must be greater-than critical value"
         end
       end
     end

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -85,7 +85,7 @@ module Kennel
         super
 
         if data[:thresholds].any? { |t| t[:warning] && t[:warning].to_f <= t[:critical].to_f }
-          invalid! "Threshold warning must be greater-than critical value"
+          invalid! :xxx11, "Threshold warning must be greater-than critical value"
         end
       end
     end

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -12,7 +12,7 @@ module Kennel
       bad = Kennel::Utils.all_keys(data).grep_v(Symbol)
       return if bad.empty?
       invalid!(
-        :xxx14,
+        :hash_keys_must_be_symbols,
         "Only use Symbols as hash keys to avoid permanent diffs when updating.\n" \
         "Change these keys to be symbols (usually 'foo' => 1 --> 'foo': 1)\n" \
         "#{bad.map(&:inspect).join("\n")}"

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -12,6 +12,7 @@ module Kennel
       bad = Kennel::Utils.all_keys(data).grep_v(Symbol)
       return if bad.empty?
       invalid!(
+        :xxx14,
         "Only use Symbols as hash keys to avoid permanent diffs when updating.\n" \
         "Change these keys to be symbols (usually 'foo' => 1 --> 'foo': 1)\n" \
         "#{bad.map(&:inspect).join("\n")}"

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -2,8 +2,8 @@
 module Kennel
   module OptionalValidations
     def self.included(base)
-      base.settings :validate
-      base.defaults(validate: -> { true })
+      base.settings :validate, :skip_validations
+      base.defaults(validate: true, skip_validations: -> { [] })
     end
 
     private

--- a/lib/kennel/template_variables.rb
+++ b/lib/kennel/template_variables.rb
@@ -29,7 +29,7 @@ module Kennel
       return if queries.empty?
 
       invalid!(
-        :xxx13,
+        :queries_must_use_template_variables,
         "queries #{queries.join(", ")} must use the template variables #{variables.join(", ")}\n" \
         "If that is not possible, add `validate: -> { false } # query foo in bar does not have baz tag`"
       )

--- a/lib/kennel/template_variables.rb
+++ b/lib/kennel/template_variables.rb
@@ -29,6 +29,7 @@ module Kennel
       return if queries.empty?
 
       invalid!(
+        :xxx13,
         "queries #{queries.join(", ")} must use the template variables #{variables.join(", ")}\n" \
         "If that is not possible, add `validate: -> { false } # query foo in bar does not have baz tag`"
       )

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -130,13 +130,13 @@ describe Kennel::Models::Monitor do
 
     it "does not allow mismatching query and critical" do
       e = assert_raises(RuntimeError) { monitor(critical: -> { 123.0 }, query: -> { "foo < 12" }).as_json }
-      e.tag.must_equal :xxx4
+      e.tag.must_equal :query_must_compare_against_critical
       e.base_message.must_equal "critical and value used in query must match"
     end
 
     it "does not allow mismatching query and critical with >=" do
       e = assert_raises(RuntimeError) { monitor(critical: -> { 123.0 }, query: -> { "foo <= 12" }).as_json }
-      e.tag.must_equal :xxx4
+      e.tag.must_equal :query_must_compare_against_critical
       e.base_message.must_equal "critical and value used in query must match"
     end
 
@@ -243,7 +243,7 @@ describe Kennel::Models::Monitor do
 
       it "fails on invalid" do
         e = assert_raises(RuntimeError) { monitor(renotify_interval: -> { 123 }).as_json }
-        e.tag.must_equal :xxx5
+        e.tag.must_equal :renotify_interval_must_be_valid
         e.base_message.must_include "renotify_interval must be one of 0, 10, 20,"
       end
     end
@@ -294,28 +294,28 @@ describe Kennel::Models::Monitor do
       it "fails when using invalid is_match" do
         mon.stubs(:message).returns('{{#is_match "environment.name" "production"}}TEST{{/is_match}}')
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.tag.must_equal :xxx9
+        e.tag.must_equal :message_must_only_use_valid_variables
         e.base_message.must_equal "Used environment.name in the message, but can only be used with env.name.\nGroup or filter the query by environment to use it."
       end
 
       it "fails when using invalid negative is_match" do
         mon.stubs(:message).returns('{{^is_match "environment.name" "production"}}TEST{{/is_match}}')
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.tag.must_equal :xxx9
+        e.tag.must_equal :message_must_only_use_valid_variables
         e.base_message.must_equal "Used environment.name in the message, but can only be used with env.name.\nGroup or filter the query by environment to use it."
       end
 
       it "fails when using invalid is_exact_match" do
         mon.stubs(:message).returns('{{#is_exact_match "environment.name" "production"}}TEST{{/is_exact_match}}')
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.tag.must_equal :xxx9
+        e.tag.must_equal :message_must_only_use_valid_variables
         e.base_message.must_equal "Used environment.name in the message, but can only be used with env.name.\nGroup or filter the query by environment to use it."
       end
 
       it "fails when not using .name" do
         mon.stubs(:message).returns('{{#is_match "env" "production"}}TEST{{/is_match}}')
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.tag.must_equal :xxx9
+        e.tag.must_equal :message_must_only_use_valid_variables
         e.base_message.must_equal "Used env in the message, but can only be used with env.name.\nGroup or filter the query by env to use it."
       end
 
@@ -350,14 +350,14 @@ describe Kennel::Models::Monitor do
         mon.stubs(:query).returns("avg(last_5m):avg:foo{*} by {env} > 123.0")
         mon.expects(:message).returns("{{bar.name}}")
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.tag.must_equal :xxx9
+        e.tag.must_equal :message_must_only_use_valid_variables
         e.base_message.must_equal "Used bar.name in the message, but can only be used with env.name.\nGroup or filter the query by bar to use it."
       end
 
       it "fails when using invalid variable" do
         mon.expects(:message).returns("{{foo.name}}")
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.tag.must_equal :xxx9
+        e.tag.must_equal :message_must_only_use_valid_variables
         e.base_message.must_equal "Used foo.name in the message, but can only be used with env.name.\nGroup or filter the query by foo to use it."
       end
 
@@ -378,7 +378,7 @@ describe Kennel::Models::Monitor do
       it "fails when using invalid is_match" do
         mon.stubs(:message).returns('{{#is_match "environment.name" "production"}}TEST{{/is_match}}')
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.tag.must_equal :xxx9
+        e.tag.must_equal :message_must_only_use_valid_variables
         e.base_message.must_equal "Used environment.name in the message, but can only be used with env.name.\nGroup or filter the query by environment to use it."
       end
 

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -130,12 +130,14 @@ describe Kennel::Models::Monitor do
 
     it "does not allow mismatching query and critical" do
       e = assert_raises(RuntimeError) { monitor(critical: -> { 123.0 }, query: -> { "foo < 12" }).as_json }
-      e.message.must_equal "test_project:m1 critical and value used in query must match"
+      e.tag.must_equal :xxx4
+      e.base_message.must_equal "critical and value used in query must match"
     end
 
     it "does not allow mismatching query and critical with >=" do
       e = assert_raises(RuntimeError) { monitor(critical: -> { 123.0 }, query: -> { "foo <= 12" }).as_json }
-      e.message.must_equal "test_project:m1 critical and value used in query must match"
+      e.tag.must_equal :xxx4
+      e.base_message.must_equal "critical and value used in query must match"
     end
 
     it "does not break on queries that are unparseable for critical" do
@@ -241,7 +243,8 @@ describe Kennel::Models::Monitor do
 
       it "fails on invalid" do
         e = assert_raises(RuntimeError) { monitor(renotify_interval: -> { 123 }).as_json }
-        e.message.must_include "test_project:m1 renotify_interval must be one of 0, 10, 20,"
+        e.tag.must_equal :xxx5
+        e.base_message.must_include "renotify_interval must be one of 0, 10, 20,"
       end
     end
 
@@ -291,25 +294,29 @@ describe Kennel::Models::Monitor do
       it "fails when using invalid is_match" do
         mon.stubs(:message).returns('{{#is_match "environment.name" "production"}}TEST{{/is_match}}')
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.message.must_equal "test_project:m1 Used environment.name in the message, but can only be used with env.name.\nGroup or filter the query by environment to use it."
+        e.tag.must_equal :xxx9
+        e.base_message.must_equal "Used environment.name in the message, but can only be used with env.name.\nGroup or filter the query by environment to use it."
       end
 
       it "fails when using invalid negative is_match" do
         mon.stubs(:message).returns('{{^is_match "environment.name" "production"}}TEST{{/is_match}}')
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.message.must_equal "test_project:m1 Used environment.name in the message, but can only be used with env.name.\nGroup or filter the query by environment to use it."
+        e.tag.must_equal :xxx9
+        e.base_message.must_equal "Used environment.name in the message, but can only be used with env.name.\nGroup or filter the query by environment to use it."
       end
 
       it "fails when using invalid is_exact_match" do
         mon.stubs(:message).returns('{{#is_exact_match "environment.name" "production"}}TEST{{/is_exact_match}}')
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.message.must_equal "test_project:m1 Used environment.name in the message, but can only be used with env.name.\nGroup or filter the query by environment to use it."
+        e.tag.must_equal :xxx9
+        e.base_message.must_equal "Used environment.name in the message, but can only be used with env.name.\nGroup or filter the query by environment to use it."
       end
 
       it "fails when not using .name" do
         mon.stubs(:message).returns('{{#is_match "env" "production"}}TEST{{/is_match}}')
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.message.must_equal "test_project:m1 Used env in the message, but can only be used with env.name.\nGroup or filter the query by env to use it."
+        e.tag.must_equal :xxx9
+        e.base_message.must_equal "Used env in the message, but can only be used with env.name.\nGroup or filter the query by env to use it."
       end
 
       it "ignores when not using quotes" do
@@ -343,13 +350,15 @@ describe Kennel::Models::Monitor do
         mon.stubs(:query).returns("avg(last_5m):avg:foo{*} by {env} > 123.0")
         mon.expects(:message).returns("{{bar.name}}")
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.message.must_equal "test_project:m1 Used bar.name in the message, but can only be used with env.name.\nGroup or filter the query by bar to use it."
+        e.tag.must_equal :xxx9
+        e.base_message.must_equal "Used bar.name in the message, but can only be used with env.name.\nGroup or filter the query by bar to use it."
       end
 
       it "fails when using invalid variable" do
         mon.expects(:message).returns("{{foo.name}}")
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.message.must_equal "test_project:m1 Used foo.name in the message, but can only be used with env.name.\nGroup or filter the query by foo to use it."
+        e.tag.must_equal :xxx9
+        e.base_message.must_equal "Used foo.name in the message, but can only be used with env.name.\nGroup or filter the query by foo to use it."
       end
 
       it "passes with [escaped] query style" do
@@ -369,7 +378,8 @@ describe Kennel::Models::Monitor do
       it "fails when using invalid is_match" do
         mon.stubs(:message).returns('{{#is_match "environment.name" "production"}}TEST{{/is_match}}')
         e = assert_raises(Kennel::ValidationError) { mon.as_json }
-        e.message.must_equal "test_project:m1 Used environment.name in the message, but can only be used with env.name.\nGroup or filter the query by environment to use it."
+        e.tag.must_equal :xxx9
+        e.base_message.must_equal "Used environment.name in the message, but can only be used with env.name.\nGroup or filter the query by environment to use it."
       end
 
       it "passes when using valid is_match" do

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -48,9 +48,10 @@ describe Kennel::Models::Record do
   describe "#invalid!" do
     it "raises a validation error whit project name to help when backtrace is generic" do
       e = assert_raises Kennel::ValidationError do
-        Kennel::Models::Monitor.new(TestProject.new, name: -> { "My Bad monitor" }, kennel_id: -> { "x" }).send(:invalid!, :xxx16, "X")
+        Kennel::Models::Monitor.new(TestProject.new, name: -> { "My Bad monitor" }, kennel_id: -> { "x" }).send(:invalid!, :some_tag, "X")
       end
-      e.message.must_equal "test_project:x X"
+      e.tag.must_equal :some_tag
+      e.base_message.must_equal "X"
     end
   end
 

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -48,7 +48,7 @@ describe Kennel::Models::Record do
   describe "#invalid!" do
     it "raises a validation error whit project name to help when backtrace is generic" do
       e = assert_raises Kennel::ValidationError do
-        Kennel::Models::Monitor.new(TestProject.new, name: -> { "My Bad monitor" }, kennel_id: -> { "x" }).send(:invalid!, "X")
+        Kennel::Models::Monitor.new(TestProject.new, name: -> { "My Bad monitor" }, kennel_id: -> { "x" }).send(:invalid!, :xxx16, "X")
       end
       e.message.must_equal "test_project:x X"
     end

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -19,8 +19,9 @@ describe Kennel::OptionalValidations do
       e = assert_raises Kennel::ValidationError do
         Kennel::Models::Dashboard.new(TestProject.new, kennel_id: -> { "test" }).send(:validate_json, 0 => 1, b: [{ "c" => 1, d: 2 }])
       end
-      e.message.must_equal(
-        "test_project:test Only use Symbols as hash keys to avoid permanent diffs when updating.\n" \
+      e.tag.must_equal :xxx14
+      e.base_message.must_equal(
+        "Only use Symbols as hash keys to avoid permanent diffs when updating.\n" \
         "Change these keys to be symbols (usually 'foo' => 1 --> 'foo': 1)\n" \
         "0\n" \
         "\"c\""

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -19,7 +19,7 @@ describe Kennel::OptionalValidations do
       e = assert_raises Kennel::ValidationError do
         Kennel::Models::Dashboard.new(TestProject.new, kennel_id: -> { "test" }).send(:validate_json, 0 => 1, b: [{ "c" => 1, d: 2 }])
       end
-      e.tag.must_equal :xxx14
+      e.tag.must_equal :hash_keys_must_be_symbols
       e.base_message.must_equal(
         "Only use Symbols as hash keys to avoid permanent diffs when updating.\n" \
         "Change these keys to be symbols (usually 'foo' => 1 --> 'foo': 1)\n" \

--- a/test/kennel/template_variables_test.rb
+++ b/test/kennel/template_variables_test.rb
@@ -51,9 +51,11 @@ describe Kennel::TemplateVariables do
     end
 
     it "is invalid when vars are not used" do
-      assert_raises Kennel::ValidationError do
+      e = assert_raises Kennel::ValidationError do
         validate ["a"], [{ definition: { requests: [{ q: "$b" }] } }]
       end
+      e.tag.must_equal :queries_must_use_template_variables
+      e.base_message.must_include "must use the template variables"
     end
 
     it "is invalid when some vars are not used" do

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -123,10 +123,12 @@ describe Kennel do
   describe Kennel::ValidationError do
     it "constructs" do
       part = {}
+      part.stubs(:tracking_id).returns("foo:bar")
       e = Kennel::ValidationError.new(part, :some_tag, "a message")
       e.part.must_equal part
       e.tag.must_equal :some_tag
-      e.message.must_equal "a message"
+      e.base_message.must_equal "a message"
+      e.message.must_equal "foo:bar E: some_tag: a message"
     end
   end
 end

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -119,4 +119,14 @@ describe Kennel do
       stderr.string.must_match(/press 'y' to continue: \e\[0m\z/m) # nothing after
     end
   end
+
+  describe Kennel::ValidationError do
+    it "constructs" do
+      part = {}
+      e = Kennel::ValidationError.new(part, :some_tag, "a message")
+      e.part.must_equal part
+      e.tag.must_equal :some_tag
+      e.message.must_equal "a message"
+    end
+  end
 end


### PR DESCRIPTION
Builds on #211 (and includes all of its commits).

Give validation errors tags, e.g. `:query_must_compare_against_critical`. Prefer suppression of individual errors (`skip_validations: [:query_must_compare_against_critical]`) over blanket suppression of all errors (`validate: false`). It is an error to use validation-suppression when no validation errors in fact occur.

The last commit is especially messy, and introduces a little non-test-covered code; I got lazy. A lot of the complexity in the last commit can go away once zendesk-kennel has migrated from `validate` to `skip_validations`.