### PR TITLE
Limit number of lines of diff output per item

### DIFF
--- a/lib/kennel/output_limiter.rb
+++ b/lib/kennel/output_limiter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Kennel
+  class OutputLimiter
+    def initialize(out, max_lines, &on_overflow)
+      @out = out
+      @max_lines = max_lines
+      @on_overflow = on_overflow
+      @seen = 0
+    end
+
+    def puts(*content)
+      content.join("\n").split("\n").each do |line|
+        if @seen >= @max_lines
+          @on_overflow&.call
+          @on_overflow = nil
+          break
+        else
+          @out.puts(line)
+          @seen += 1
+        end
+      end
+    end
+  end
+end

--- a/test/kennel/output_limiter_test.rb
+++ b/test/kennel/output_limiter_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require_relative "../test_helper"
+require "kennel/output_limiter"
+
+SingleCov.covered!
+
+describe Kennel::OutputLimiter do
+  it "can show short output" do
+    out, _err = capture_io do
+      limiter = Kennel::OutputLimiter.new($stdout, 10)
+      5.times { |n| limiter.puts n }
+    end
+    out.must_equal "0\n1\n2\n3\n4\n"
+  end
+
+  it "can show up to the limit" do
+    out, _err = capture_io do
+      limiter = Kennel::OutputLimiter.new($stdout, 5)
+      5.times { |n| limiter.puts n }
+    end
+    out.must_equal "0\n1\n2\n3\n4\n"
+  end
+
+  it "stops at the limit (without a block)" do
+    out, _err = capture_io do
+      limiter = Kennel::OutputLimiter.new($stdout, 3)
+      5.times { |n| limiter.puts n }
+    end
+    out.must_equal "0\n1\n2\n"
+  end
+
+  it "stops at the limit (with a block)" do
+    times = 0
+    callback = -> { times += 1 }
+    out, _err = capture_io do
+      limiter = Kennel::OutputLimiter.new($stdout, 3, &callback)
+      5.times { |n| limiter.puts n }
+    end
+    out.must_equal "0\n1\n2\n"
+    times.must_equal 1
+  end
+end

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -182,6 +182,24 @@ describe Kennel::Syncer do
       TEXT
     end
 
+    it "limits the size of diffs" do
+      expected << monitor("a", "b", foo: "")
+      monitors << monitor_api_response("a", "b", foo: 100.times.map(&:to_s).join("\n"))
+      output.must_include "- 48\n"
+      output.wont_include "- 49\n"
+      output.must_include "(Diff for this item truncated after 50 lines. Rerun with MAX_DIFF_LINES=100 to see more)"
+    end
+
+    it "can configure the diff size limit" do
+      with_env("MAX_DIFF_LINES" => "20") do
+        expected << monitor("a", "b", foo: "")
+        monitors << monitor_api_response("a", "b", foo: 100.times.map(&:to_s).join("\n"))
+        output.must_include "- 18\n"
+        output.wont_include "- 19\n"
+        output.must_include "(Diff for this item truncated after 20 lines. Rerun with MAX_DIFF_LINES=40 to see more)"
+      end
+    end
+
     it "shows added tags nicely" do
       expected << monitor("a", "b", tags: ["foo", "bar"])
       monitors << monitor_api_response("a", "b", tags: ["foo", "baz"])


### PR DESCRIPTION
Dashboard widget diffs can be uselessly large.

<img width="996" alt="image" src="https://user-images.githubusercontent.com/48241875/197317493-3fdfda97-740d-4be9-afff-508ac13a775a.png">
