### PR TITLE
pre-download sketch

### DIFF
--- a/lib/kennel/downloader.rb
+++ b/lib/kennel/downloader.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+# encapsulates knowledge around how the api works
+# especially 1-off weirdness that should not lak into other parts of the code
+module Kennel
+  class Downloader
+    def initialize(api)
+      @api = api
+      @mutex = Mutex.new
+    end
+
+    def definitions
+      @mutex.synchronize { @definitions ||= download_definitions }
+    end
+
+    attr_reader :time_taken
+
+    private
+
+    def download_definitions
+      t0 = Time.now
+      Utils.parallel(Models::Record.subclasses) do |klass|
+        results = @api.list(klass.api_resource, with_downtimes: false) # lookup monitors without adding unnecessary downtime information
+        results = results[results.keys.first] if results.is_a?(Hash) # dashboards are nested in {dashboards: []}
+        results.each { |a| cache_metadata(a, klass) }
+      end.flatten(1).tap do
+        @time_taken = Time.now - t0
+      end
+    end
+
+    def cache_metadata(a, klass)
+      a[:klass] = klass
+      a[:tracking_id] = a.fetch(:klass).parse_tracking_id(a)
+    end
+  end
+end


### PR DESCRIPTION
If it looks like we're going to get as far as syncer "plan" (and possibly "update"), then we're going to need to `download_definitions` from datadog, which can take quite a few seconds. So start it earlier, so that it's got a better chance of being ready in time.

Very small data sample of test runs on kennel-config master with no changes, running "rake generate plan":

- without this PR: approx 31-32 seconds
- with this PR: aprox 24-29 seconds

---

Nowhere near ready yet, and although it achieves the goal of making kennel faster, I've also broken updates (cache_metadata is used by syncer after creates). So there's a bit more work to do, plus testing etc.
