### PR TITLE
Use the correct kennel instance when checking strict_imports

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -84,7 +84,7 @@ module Kennel
     end
 
     def syncer
-      @syncer ||= Syncer.new(api, generated, project_filter: filter.project_filter, tracking_id_filter: filter.tracking_id_filter)
+      @syncer ||= Syncer.new(api, generated, kennel: self, project_filter: filter.project_filter, tracking_id_filter: filter.tracking_id_filter)
     end
 
     def api


### PR DESCRIPTION
The "Compatibility" mechanism makes things confusing, because it means that there is both a right and a wrong way to do things, instead of only a right way.
