### PR TITLE
download definitions while generating to speed up plan and update

### DIFF
--- a/lib/kennel/progress.rb
+++ b/lib/kennel/progress.rb
@@ -4,8 +4,8 @@ require "benchmark"
 module Kennel
   class Progress
     # print what we are doing and a spinner until it is done ... then show how long it took
-    def self.progress(name, interval: 0.2, &block)
-      return progress_no_tty(name, &block) unless Kennel.err.tty?
+    def self.progress(name, interval: 0.2, plain: false, &block)
+      return progress_no_tty(name, &block) if plain || !Kennel.err.tty?
 
       Kennel.err.print "#{name} ... "
 

--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -102,8 +102,9 @@ namespace :kennel do
 
   # also generate parts so users see and commit updated generated automatically
   desc "show planned datadog changes (scope with PROJECT=name)"
-  task plan: :generate do
+  task plan: :environment do
     Kennel::Tasks.kennel.plan
+    Kennel::Tasks.kennel.generate
   end
 
   desc "update datadog (scope with PROJECT=name)"

--- a/lib/kennel/utils.rb
+++ b/lib/kennel/utils.rb
@@ -160,6 +160,11 @@ module Kennel
         end
         string
       end
+
+      def inline_resource_metadata(resource, klass)
+        resource[:klass] = klass
+        resource[:tracking_id] = klass.parse_tracking_id(resource)
+      end
     end
   end
 end

--- a/test/integration.rb
+++ b/test/integration.rb
@@ -40,19 +40,19 @@ describe "Integration" do
     # result = sh "echo y | bundle exec rake kennel:update_datadog" # Uncomment this to apply know good diff
     result = sh "bundle exec rake plan 2>&1"
     result.gsub!(/\d\.\d+s/, "0.00s")
-    result.must_equal <<~TXT
-      Finding parts ...
-      Finding parts ... 0.00s
+    progress, plan = result.split("Plan:\n")
+    progress.split("\n").sort.join("\n").must_equal <<~TXT.rstrip
       Building json ...
       Building json ... 0.00s
-      Storing ...
-      Storing ... 0.00s
-      Downloading definitions ...
-      Downloading definitions ... 0.00s
       Diffing ...
       Diffing ... 0.00s
-      Plan:
-      Nothing to do
+      Downloading definitions ...
+      Downloading definitions ... 0.00s
+      Finding parts ...
+      Finding parts ... 0.00s
+      Storing ...
+      Storing ... 0.00s
     TXT
+    plan.must_equal "Nothing to do\n"
   end
 end

--- a/test/kennel/progress_test.rb
+++ b/test/kennel/progress_test.rb
@@ -7,7 +7,7 @@ describe Kennel::Progress do
   capture_all
 
   describe ".progress" do
-    it "shows progress (with tty)" do
+    it "shows animated progress with tty" do
       Kennel.err.stubs(:tty?).returns(true)
       result = Kennel::Progress.progress("foo", interval: 0.01) do
         sleep 0.10 # make progress print multiple times
@@ -18,14 +18,24 @@ describe Kennel::Progress do
       stderr.string.sub(/-.*?0/, "0").gsub(/\d\.\d+/, "1.11").must_equal "foo ... 1.11s\n"
     end
 
-    it "shows progress (without tty)" do
+    it "shows plain progress without tty" do
       Kennel.err.stubs(:tty?).returns(false)
       result = Kennel::Progress.progress("foo", interval: 0.01) do
         sleep 0.10 # if there were a tty, this would make it print the spinner
         123
       end
       result.must_equal 123
-      stderr.string.sub(/-.*?0/, "0").gsub(/\d\.\d+/, "1.11").must_equal "foo ...\nfoo ... 1.11s\n"
+      stderr.string.gsub(/\d\.\d+/, "1.11").must_equal "foo ...\nfoo ... 1.11s\n"
+    end
+
+    it "shows plain progress with plain" do
+      Kennel.err.stubs(:tty?).never
+      result = Kennel::Progress.progress("foo", interval: 0.01, plain: true) do
+        sleep 0.10 # if there were a tty, this would make it print the spinner
+        123
+      end
+      result.must_equal 123
+      stderr.string.gsub(/\d\.\d+/, "1.11").must_equal "foo ...\nfoo ... 1.11s\n"
     end
 
     it "stops immediately when block finishes" do
@@ -45,7 +55,6 @@ describe Kennel::Progress do
         end
       end
       final = stderr.string
-      # p final
       sleep 0.01
       stderr.string.must_equal final, "progress was not stopped"
     end

--- a/test/kennel/tasks_test.rb
+++ b/test/kennel/tasks_test.rb
@@ -3,7 +3,7 @@ require_relative "../test_helper"
 require "rake"
 require "kennel/tasks"
 
-SingleCov.covered! uncovered: 43 # TODO: reduce this
+SingleCov.covered! uncovered: 44 # TODO: reduce this
 
 describe "tasks" do
   enable_api

--- a/test/kennel/utils_test.rb
+++ b/test/kennel/utils_test.rb
@@ -275,4 +275,13 @@ describe Kennel::Utils do
       Kennel::Utils.pretty_inspect([{ foo: { bar: "bar" } }]).must_equal "[{ foo: { bar: \"bar\" } }]"
     end
   end
+
+  describe ".inline_resource_metadata" do
+    it "adds klass and tracking_id" do
+      resource = { message: "-- Managed by kennel a:b" }
+      Kennel::Utils.inline_resource_metadata(resource, Kennel::Models::Monitor)
+      resource[:tracking_id].must_equal "a:b"
+      resource[:klass].must_equal Kennel::Models::Monitor
+    end
+  end
 end


### PR DESCRIPTION
before (latest release):
```
time bundle exec rake kennel:plan PROJECT=foo
Generating ... 1.51s
Storing ... 0.01s
Downloading definitions ... 7.09s
Diffing ... 0.3s
Plan:
Nothing to do

real	0m10.006s
user	0m3.593s
sys	0m0.551s
```

after:
```
time bundle exec rake kennel:plan PROJECT=foo
Downloading definitions ...
Finding parts ...
Finding parts ... 1.56s
Building json ... 0.01s
Downloading definitions ... 6.6s
Diffing ... 0.1s
Plan:
Nothing to do

real	0m7.228s
user	0m3.455s
sys	0m0.552s
```

rework of https://github.com/grosser/kennel/pull/216

@zdrve 