### PR TITLE
Fail / Report modes for `validate: false`

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -39,7 +39,6 @@ module Teams
 end
 
 module Kennel
-  ValidationMessage = Struct.new(:text)
   UnresolvableIdError = Class.new(StandardError)
   DisallowedUpdateError = Class.new(StandardError)
   GenerationAbortedError = Class.new(StandardError)

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -40,10 +40,9 @@ end
 
 module Kennel
   ValidationMessage = Struct.new(:text)
-  ValidationError = Class.new(RuntimeError)
-  UnresolvableIdError = Class.new(RuntimeError)
-  DisallowedUpdateError = Class.new(RuntimeError)
-  GenerationAbortedError = Class.new(RuntimeError)
+  UnresolvableIdError = Class.new(StandardError)
+  DisallowedUpdateError = Class.new(StandardError)
+  GenerationAbortedError = Class.new(StandardError)
   UpdateResult = Struct.new(:plan, :update, keyword_init: true)
 
   class << self

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -39,7 +39,7 @@ module Teams
 end
 
 module Kennel
-  ValidationMessage = Struct.new(:message)
+  ValidationMessage = Struct.new(:text)
   ValidationError = Class.new(RuntimeError)
   UnresolvableIdError = Class.new(RuntimeError)
   DisallowedUpdateError = Class.new(RuntimeError)

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -39,6 +39,7 @@ module Teams
 end
 
 module Kennel
+  ValidationMessage = Struct.new(:message)
   ValidationError = Class.new(RuntimeError)
   UnresolvableIdError = Class.new(RuntimeError)
   DisallowedUpdateError = Class.new(RuntimeError)

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -156,7 +156,7 @@ module Kennel
       def as_json
         # A courtesy to those tests that still expect as_json to perform validation and raise on error
         build if @validation_errors.nil?
-        raise Kennel::ValidationError, "#{safe_tracking_id} #{@validation_errors.first}" unless validation_errors.empty?
+        raise Kennel::ValidationError, "#{safe_tracking_id} #{@validation_errors.first.message}" unless validation_errors.empty?
 
         @as_json
       end
@@ -209,7 +209,7 @@ module Kennel
       end
 
       def invalid!(message)
-        validation_errors << message
+        validation_errors << ValidationMessage.new(message)
       end
 
       def raise_with_location(error, message)

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -150,13 +150,7 @@ module Kennel
           end
         end
 
-        @filtered_validation_errors =
-          if validate
-            unfiltered_validation_errors
-          else
-            []
-          end
-
+        @filtered_validation_errors = filter_validation_errors
         @as_json = json # Only valid if filtered_validation_errors.empty?
       end
 

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -156,7 +156,7 @@ module Kennel
       def as_json
         # A courtesy to those tests that still expect as_json to perform validation and raise on error
         build if @validation_errors.nil?
-        raise Kennel::ValidationError, "#{safe_tracking_id} #{@validation_errors.first.message}" unless validation_errors.empty?
+        raise Kennel::ValidationError, "#{safe_tracking_id} as_json called on invalid part" unless validation_errors.empty?
 
         @as_json
       end

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -82,7 +82,7 @@ module Kennel
         end
       end
 
-      attr_reader :project, :validation_errors
+      attr_reader :project, :unfiltered_validation_errors
 
       def initialize(project, *args)
         raise ArgumentError, "First argument must be a project, not #{project.class}" unless project.is_a?(Project)
@@ -136,7 +136,7 @@ module Kennel
       end
 
       def build
-        @validation_errors = []
+        @unfiltered_validation_errors = []
         json = nil
 
         begin
@@ -144,19 +144,19 @@ module Kennel
           (id = json.delete(:id)) && json[:id] = id
           validate_json(json) if validate
         rescue StandardError
-          if validation_errors.empty?
-            @validation_errors = nil
+          if unfiltered_validation_errors.empty?
+            @unfiltered_validation_errors = nil
             raise PrepareError, safe_tracking_id
           end
         end
 
-        @as_json = json # Only valid if validation_errors.empty?
+        @as_json = json # Only valid if unfiltered_validation_errors.empty?
       end
 
       def as_json
         # A courtesy to those tests that still expect as_json to perform validation and raise on error
-        build if @validation_errors.nil?
-        raise Kennel::ValidationError, "#{safe_tracking_id} as_json called on invalid part" unless validation_errors.empty?
+        build if @unfiltered_validation_errors.nil?
+        raise Kennel::ValidationError, "#{safe_tracking_id} as_json called on invalid part" unless unfiltered_validation_errors.empty?
 
         @as_json
       end
@@ -209,7 +209,7 @@ module Kennel
       end
 
       def invalid!(message)
-        validation_errors << ValidationMessage.new(message)
+        unfiltered_validation_errors << ValidationMessage.new(message)
       end
 
       def raise_with_location(error, message)

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -8,6 +8,8 @@ module Kennel
         end
       end
 
+      UnvalidatedRecordError = Class.new(StandardError)
+
       include OptionalValidations
 
       # Apart from if you just don't like the default for some reason,
@@ -157,7 +159,7 @@ module Kennel
       def as_json
         # A courtesy to those tests that still expect as_json to perform validation and raise on error
         build if @unfiltered_validation_errors.nil?
-        raise Kennel::ValidationError, "#{safe_tracking_id} as_json called on invalid part" unless filtered_validation_errors.empty?
+        raise UnvalidatedRecordError, "#{safe_tracking_id} as_json called on invalid part" unless filtered_validation_errors.empty?
 
         @as_json
       end

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Kennel
   module OptionalValidations
+    ValidationMessage = Struct.new(:text)
+
     def self.included(base)
       base.settings :validate
       base.defaults(validate: -> { true })

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -16,7 +16,7 @@ module Kennel
       Kennel.err.puts
       parts_with_errors.sort_by(&:safe_tracking_id).each do |part|
         part.filtered_validation_errors.each do |err|
-          Kennel.err.puts "#{part.safe_tracking_id} #{err}"
+          Kennel.err.puts "#{part.safe_tracking_id} #{err.message}"
         end
       end
       Kennel.err.puts
@@ -51,7 +51,7 @@ module Kennel
         end
 
         if mode == "fail"
-          [msg]
+          [ValidationError.new(msg)]
         else
           Kennel.out.puts "#{safe_tracking_id} #{msg}" if mode == "show"
           []

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -8,14 +8,14 @@ module Kennel
 
     def self.valid?(parts)
       parts_with_errors = parts.reject do |part|
-        part.validation_errors.empty?
+        part.unfiltered_validation_errors.empty?
       end
 
       return true if parts_with_errors.empty?
 
       Kennel.err.puts
       parts_with_errors.sort_by(&:safe_tracking_id).each do |part|
-        part.validation_errors.each do |err|
+        part.unfiltered_validation_errors.each do |err|
           Kennel.err.puts "#{part.safe_tracking_id} #{err}"
         end
       end

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -51,7 +51,7 @@ module Kennel
         end
 
         if mode == "fail"
-          [ValidationError.new(msg)]
+          [ValidationMessage.new(msg)]
         else
           Kennel.out.puts "#{safe_tracking_id} #{msg}" if mode == "show"
           []

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -8,14 +8,14 @@ module Kennel
 
     def self.valid?(parts)
       parts_with_errors = parts.reject do |part|
-        part.unfiltered_validation_errors.empty?
+        part.filtered_validation_errors.empty?
       end
 
       return true if parts_with_errors.empty?
 
       Kennel.err.puts
       parts_with_errors.sort_by(&:safe_tracking_id).each do |part|
-        part.unfiltered_validation_errors.each do |err|
+        part.filtered_validation_errors.each do |err|
           Kennel.err.puts "#{part.safe_tracking_id} #{err}"
         end
       end

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -16,7 +16,7 @@ module Kennel
       Kennel.err.puts
       parts_with_errors.sort_by(&:safe_tracking_id).each do |part|
         part.filtered_validation_errors.each do |err|
-          Kennel.err.puts "#{part.safe_tracking_id} #{err.message}"
+          Kennel.err.puts "#{part.safe_tracking_id} #{err.text}"
         end
       end
       Kennel.err.puts
@@ -64,7 +64,7 @@ module Kennel
         else
           if mode == "show"
             unfiltered_validation_errors.each do |err|
-              Kennel.out.puts "#{safe_tracking_id} `validate: false` suppressing error: #{err.message.gsub("\n", " ")}"
+              Kennel.out.puts "#{safe_tracking_id} `validate: false` suppressing error: #{err.text.gsub("\n", " ")}"
             end
           end
 

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -64,9 +64,8 @@ describe Kennel::Models::Dashboard do
     end
 
     it "complains when datadog would created a diff by sorting template_variable_presets" do
-      assert_raises Kennel::ValidationError do
-        dashboard(template_variable_presets: -> { [{ name: "B" }, { name: "A" }] }).as_json
-      end
+      validation_error_from(dashboard(template_variable_presets: -> { [{ name: "B" }, { name: "A" }] }))
+        .must_equal "template_variable_presets must be sorted by name"
     end
 
     it "doesn't complain on sorted template_variable_presets" do

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -52,7 +52,7 @@ describe Kennel::Models::Record do
       record.define_singleton_method(:build_json) { some_json }
       record.define_singleton_method(:validate_json) { |data| data.must_equal(some_json) }
       record.build
-      record.validation_errors.must_equal []
+      record.unfiltered_validation_errors.must_equal []
       record.as_json.must_equal some_json
     end
 
@@ -60,14 +60,14 @@ describe Kennel::Models::Record do
       record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x")
       record.define_singleton_method(:build_json) { raise "I crashed :-(" }
       assert_raises("I crashed :-(") { record.build }
-      record.validation_errors.must_be_nil
+      record.unfiltered_validation_errors.must_be_nil
     end
 
     it "throws if validate_json throws, and there were no validation errors" do
       record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x")
       record.define_singleton_method(:validate_json) { |_data| raise "I crashed :-(" }
       assert_raises("I crashed :-(") { record.build }
-      record.validation_errors.must_be_nil
+      record.unfiltered_validation_errors.must_be_nil
     end
 
     it "does not throw if build_json throws after a validation error" do
@@ -77,7 +77,7 @@ describe Kennel::Models::Record do
         raise "I crashed :-("
       end
       record.build
-      record.validation_errors.map(&:message).must_equal ["This is all wrong"]
+      record.unfiltered_validation_errors.map(&:message).must_equal ["This is all wrong"]
       record.instance_variable_get(:@as_json).must_be_nil
     end
 
@@ -88,7 +88,7 @@ describe Kennel::Models::Record do
         raise "I crashed :-("
       end
       record.build
-      record.validation_errors.map(&:message).must_equal ["This is all wrong"]
+      record.unfiltered_validation_errors.map(&:message).must_equal ["This is all wrong"]
       record.instance_variable_get(:@as_json).wont_be_nil # for debugging
     end
 
@@ -99,7 +99,7 @@ describe Kennel::Models::Record do
         invalid! "two"
       end
       record.build
-      record.validation_errors.map(&:message).must_equal ["one", "two"]
+      record.unfiltered_validation_errors.map(&:message).must_equal ["one", "two"]
       record.instance_variable_get(:@as_json).wont_be_nil # for debugging
     end
 
@@ -109,7 +109,7 @@ describe Kennel::Models::Record do
       record.stubs(:build_json).returns(some_json)
       record.stubs(:validate_json).never
       record.build
-      record.validation_errors.must_be_empty
+      record.unfiltered_validation_errors.must_be_empty
       record.instance_variable_get(:@as_json).must_equal(some_json)
     end
   end

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -149,14 +149,14 @@ describe Kennel::Models::Record do
       it "does not call build if already built" do
         record.stubs(:build_json).once.returns({})
         record.build
-        assert_raises(Kennel::ValidationError) { record.as_json }
-        assert_raises(Kennel::ValidationError) { record.as_json }
+        assert_raises(Kennel::Models::Record::UnvalidatedRecordError) { record.as_json }
+        assert_raises(Kennel::Models::Record::UnvalidatedRecordError) { record.as_json }
       end
 
       it "calls build if not already built" do
         record.stubs(:build_json).once.returns({})
-        assert_raises(Kennel::ValidationError) { record.as_json }
-        assert_raises(Kennel::ValidationError) { record.as_json }
+        assert_raises(Kennel::Models::Record::UnvalidatedRecordError) { record.as_json }
+        assert_raises(Kennel::Models::Record::UnvalidatedRecordError) { record.as_json }
       end
     end
 

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -77,7 +77,7 @@ describe Kennel::Models::Record do
         raise "I crashed :-("
       end
       record.build
-      record.unfiltered_validation_errors.map(&:message).must_equal ["This is all wrong"]
+      record.unfiltered_validation_errors.map(&:text).must_equal ["This is all wrong"]
       record.instance_variable_get(:@as_json).must_be_nil
     end
 
@@ -88,7 +88,7 @@ describe Kennel::Models::Record do
         raise "I crashed :-("
       end
       record.build
-      record.unfiltered_validation_errors.map(&:message).must_equal ["This is all wrong"]
+      record.unfiltered_validation_errors.map(&:text).must_equal ["This is all wrong"]
       record.instance_variable_get(:@as_json).wont_be_nil # for debugging
     end
 
@@ -99,7 +99,7 @@ describe Kennel::Models::Record do
         invalid! "two"
       end
       record.build
-      record.filtered_validation_errors.map(&:message).must_equal ["one", "two"]
+      record.filtered_validation_errors.map(&:text).must_equal ["one", "two"]
       record.instance_variable_get(:@as_json).wont_be_nil # for debugging
     end
 

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -186,20 +186,6 @@ describe Kennel::Models::Record do
     end
   end
 
-  describe "#invalid!" do
-    it "raises a validation error with project name to help when backtrace is generic" do
-      record = Kennel::Models::Record.new(TestProject.new, kennel_id: -> { "x" })
-      record.define_singleton_method(:validate_json) do |_data|
-        invalid! "Bang"
-      end
-
-      e = assert_raises Kennel::ValidationError do
-        record.as_json
-      end
-      e.message.must_equal "test_project:x Bang"
-    end
-  end
-
   describe "#resolve" do
     let(:base) { Kennel::Models::Monitor.new(TestProject.new, kennel_id: -> { "test" }) }
 

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -77,7 +77,7 @@ describe Kennel::Models::Record do
         raise "I crashed :-("
       end
       record.build
-      record.validation_errors.must_equal ["This is all wrong"]
+      record.validation_errors.map(&:message).must_equal ["This is all wrong"]
       record.instance_variable_get(:@as_json).must_be_nil
     end
 
@@ -88,7 +88,7 @@ describe Kennel::Models::Record do
         raise "I crashed :-("
       end
       record.build
-      record.validation_errors.must_equal ["This is all wrong"]
+      record.validation_errors.map(&:message).must_equal ["This is all wrong"]
       record.instance_variable_get(:@as_json).wont_be_nil # for debugging
     end
 
@@ -99,7 +99,7 @@ describe Kennel::Models::Record do
         invalid! "two"
       end
       record.build
-      record.validation_errors.must_equal ["one", "two"]
+      record.validation_errors.map(&:message).must_equal ["one", "two"]
       record.instance_variable_get(:@as_json).wont_be_nil # for debugging
     end
 

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -99,18 +99,19 @@ describe Kennel::Models::Record do
         invalid! "two"
       end
       record.build
-      record.unfiltered_validation_errors.map(&:message).must_equal ["one", "two"]
+      record.filtered_validation_errors.map(&:message).must_equal ["one", "two"]
       record.instance_variable_get(:@as_json).wont_be_nil # for debugging
     end
 
     it "can skip validation entirely" do
-      some_json = { some: "json" }
       record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x", validate: false)
-      record.stubs(:build_json).returns(some_json)
-      record.stubs(:validate_json).never
+      record.define_singleton_method(:validate_json) do |_data|
+        invalid! "bang"
+      end
       record.build
-      record.unfiltered_validation_errors.must_be_empty
-      record.instance_variable_get(:@as_json).must_equal(some_json)
+
+      record.filtered_validation_errors.must_be_empty
+      record.instance_variable_get(:@as_json).wont_be_nil # it's valid
     end
   end
 

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -122,13 +122,13 @@ describe Kennel::Models::Slo do
     end
 
     it "is invalid if warning < critical" do
-      s = slo(thresholds: [{ warning: 0, critical: 99 }])
-      assert_raises(Kennel::ValidationError) { s.as_json }
+      validation_error_from(slo(thresholds: [{ warning: 0, critical: 99 }]))
+        .must_equal "Threshold warning must be greater-than critical value"
     end
 
     it "is invalid if warning == critical" do
-      s = slo(thresholds: [{ warning: 99, critical: 99 }])
-      assert_raises(Kennel::ValidationError) { s.as_json }
+      validation_error_from(slo(thresholds: [{ warning: 99, critical: 99 }]))
+        .must_equal "Threshold warning must be greater-than critical value"
     end
   end
 

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -52,7 +52,13 @@ describe Kennel::OptionalValidations do
 
     it "runs with a bad part" do
       parts = [
-        bad("foo", [Kennel::ValidationMessage.new("your data is bad"), Kennel::ValidationMessage.new("and you should feel bad")])
+        bad(
+          "foo",
+          [
+            Kennel::OptionalValidations::ValidationMessage.new("your data is bad"),
+            Kennel::OptionalValidations::ValidationMessage.new("and you should feel bad")
+          ]
+        )
       ]
       refute Kennel::OptionalValidations.valid?(parts)
       stdout.string.must_equal ""

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -27,14 +27,14 @@ describe Kennel::OptionalValidations do
 
     def good
       part = mock
-      part.stubs(:unfiltered_validation_errors).returns([])
+      part.stubs(:filtered_validation_errors).returns([])
       part
     end
 
     def bad(id, errors)
       part = mock
       part.stubs(:safe_tracking_id).returns(id)
-      part.stubs(:unfiltered_validation_errors).returns(errors)
+      part.stubs(:filtered_validation_errors).returns(errors)
       part
     end
 

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -51,13 +51,10 @@ describe Kennel::OptionalValidations do
     end
 
     it "runs with a bad part" do
-      refute(
-        Kennel::OptionalValidations.valid?(
-          [
-            bad("foo", [Kennel::ValidationError.new("your data is bad"), Kennel::ValidationError.new("and you should feel bad")])
-          ]
-        )
-      )
+      parts = [
+        bad("foo", [Kennel::ValidationError.new("your data is bad"), Kennel::ValidationError.new("and you should feel bad")])
+      ]
+      refute Kennel::OptionalValidations.valid?(parts)
       stdout.string.must_equal ""
       stderr.string.must_equal <<~TEXT
 

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -52,7 +52,7 @@ describe Kennel::OptionalValidations do
 
     it "runs with a bad part" do
       parts = [
-        bad("foo", [Kennel::ValidationError.new("your data is bad"), Kennel::ValidationError.new("and you should feel bad")])
+        bad("foo", [Kennel::ValidationMessage.new("your data is bad"), Kennel::ValidationMessage.new("and you should feel bad")])
       ]
       refute Kennel::OptionalValidations.valid?(parts)
       stdout.string.must_equal ""

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -54,7 +54,7 @@ describe Kennel::OptionalValidations do
       refute(
         Kennel::OptionalValidations.valid?(
           [
-            bad("foo", ["your data is bad", "and you should feel bad"])
+            bad("foo", [Kennel::ValidationError.new("your data is bad"), Kennel::ValidationError.new("and you should feel bad")])
           ]
         )
       )

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -27,14 +27,14 @@ describe Kennel::OptionalValidations do
 
     def good
       part = mock
-      part.stubs(:validation_errors).returns([])
+      part.stubs(:unfiltered_validation_errors).returns([])
       part
     end
 
     def bad(id, errors)
       part = mock
       part.stubs(:safe_tracking_id).returns(id)
-      part.stubs(:validation_errors).returns(errors)
+      part.stubs(:unfiltered_validation_errors).returns(errors)
       part
     end
 

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative "../test_helper"
 
-SingleCov.covered!
+SingleCov.covered! uncovered: 19
 
 describe Kennel::OptionalValidations do
   with_test_classes

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -121,7 +121,7 @@ Minitest::Test.class_eval do
 
   def validation_errors_from(part)
     part.build
-    part.unfiltered_validation_errors.map(&:message)
+    part.unfiltered_validation_errors.map(&:text)
   end
 
   def validation_error_from(part)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -121,7 +121,7 @@ Minitest::Test.class_eval do
 
   def validation_errors_from(part)
     part.build
-    part.validation_errors.map(&:message)
+    part.unfiltered_validation_errors.map(&:message)
   end
 
   def validation_error_from(part)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -119,7 +119,14 @@ Minitest::Test.class_eval do
     JSON.pretty_generate(a).must_equal JSON.pretty_generate(b)
   end
 
-  def validation_error_message(&block)
-    assert_raises(Kennel::ValidationError, &block).message
+  def validation_errors_from(part)
+    part.build
+    part.validation_errors.map(&:message)
+  end
+
+  def validation_error_from(part)
+    errors = validation_errors_from(part)
+    errors.length.must_equal(1, "Expected 1 error, got #{errors.inspect}")
+    errors.first
   end
 end


### PR DESCRIPTION
Working towards error tagging, i.e. more fine-grained error suppression.

In terms of functionality, what this PR adds is new behaviours for `validate: false`: 

If `validate: false` is used, but there are no validation errors (i.e. you could set `validate: true` and it would still work), then what happens is governed by env var `UNNECESSARY_VALIDATE_FALSE`:

 * `fail` (causes a validation error)
 * `show` (print to stdout and continue)
 * (everything else) ignore

The default is `fail` if filtering is in use (but maybe `show` would be better?), otherwise ignore.

(_Update_: I removed all of the unnecessary `validate: false`s the other day, so the above is not going to hit much any more)

If `validate: false` is used and there _are_ validation errors, then what happens is governed by env var `SUPPRESSED_ERRORS`:

 * `fail` (causes validation to fail anyway, i.e. effectively sets `validate` back to true)
 * `show` (print to stdout and continue)
 * (everything else) ignore

The default is `ignore`.
