### PR TITLE
log alert: do not break UI with invalid no_data_timeframe

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -39,7 +39,7 @@ module Kennel
         renotify_interval: -> { project.team.renotify_interval },
         warning: -> { nil },
         ok: -> { nil },
-        notify_no_data: -> { true }, # datadog sets this to false by default, but true is the safer
+        notify_no_data: -> { true }, # datadog UI sets this to false by default, but true is safer
         no_data_timeframe: -> { 60 },
         notify_audit: -> { MONITOR_OPTION_DEFAULTS.fetch(:notify_audit) },
         new_host_delay: -> { MONITOR_OPTION_DEFAULTS.fetch(:new_host_delay) },
@@ -97,6 +97,12 @@ module Kennel
             # metric and query values are stored as float by datadog
             thresholds.each { |k, v| thresholds[k] = Float(v) }
           end
+        end
+
+        # setting this via the api breaks the UI with
+        # "The no_data_timeframe option is not allowed for log alert monitors"
+        if data.fetch(:type) == "log alert"
+          options.delete :no_data_timeframe
         end
 
         if windows = threshold_windows

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -229,6 +229,14 @@ describe Kennel::Models::Monitor do
         .must_equal "timeout_h must be <= 24"
     end
 
+    it "does not set no_data_timeframe for log alert to not break the UI" do
+      json = monitor(
+        type: -> { "log alert" },
+        no_data_timeframe: -> { 10 }
+      ).as_json
+      refute json[:options].key?(:no_data_timeframe)
+    end
+
     describe "renotify_interval" do
       it "sets 0 when disabled" do
         monitor(renotify_interval: -> { false }).as_json[:options][:renotify_interval].must_equal 0


### PR DESCRIPTION
it's settable via the api, but if the monitor is ever saved via the UI it fails with the "The no_data_timeframe option is not allowed for log alert monitors" error message.