### PR TITLE
Fix plan update tag

### DIFF
--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -33,7 +33,7 @@ module Kennel
       Plan.new(
         changes:
           @create.map { |_id, e| [:create, e.class.api_resource, e.tracking_id, nil] } +
-          @update.map { |_id, e| [:create, e.class.api_resource, e.tracking_id, nil] } +
+          @update.map { |_id, e| [:update, e.class.api_resource, e.tracking_id, nil] } +
           @delete.map { |_id, _e, a| [:delete, a.fetch(:klass).api_resource, a.fetch(:tracking_id), a.fetch(:id)] }
       )
     end


### PR DESCRIPTION
* Updates should be return as `:update` not `:create`
* Represent changes as structs (`c.type, c.id, ...`) instead of 4-element arrays

Backwards incompatible. Will require changes in Zendesk `ci_and_notify`

----

The failing test is failing on kennel-lib `master` :-( 