### PR TITLE
Validation error tagging / ignoring

### DIFF
--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -230,7 +230,9 @@ module Kennel
 
         # Avoid diff from datadog presets sorting.
         presets = data[:template_variable_presets]
-        invalid! "template_variable_presets must be sorted by name" if presets && presets != presets.sort_by { |p| p[:name] }
+        if presets && presets != presets.sort_by { |p| p[:name] }
+          invalid! :template_variable_presets_must_be_sorted, "template_variable_presets must be sorted by name"
+        end
       end
 
       def render_definitions(definitions)

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -211,26 +211,26 @@ module Kennel
         super
 
         if data[:name]&.start_with?(" ")
-          invalid! "name cannot start with a space"
+          invalid! :name_must_not_start_with_space, "name cannot start with a space"
         end
 
         type = data.fetch(:type)
 
         # do not allow deprecated type that will be coverted by datadog and then produce a diff
         if type == "metric alert"
-          invalid! "type 'metric alert' is deprecated, please set to a different type (e.g. 'query alert')"
+          invalid! :metric_alert_is_deprecated, "type 'metric alert' is deprecated, please set to a different type (e.g. 'query alert')"
         end
 
         # verify query includes critical value
         if query_value = data.fetch(:query)[/\s*[<>]=?\s*(\d+(\.\d+)?)\s*$/, 1]
           if Float(query_value) != Float(data.dig(:options, :thresholds, :critical))
-            invalid! "critical and value used in query must match"
+            invalid! :critical_does_not_match_query, "critical and value used in query must match"
           end
         end
 
         # verify renotify interval is valid
         unless RENOTIFY_INTERVALS.include? data.dig(:options, :renotify_interval)
-          invalid! "renotify_interval must be one of #{RENOTIFY_INTERVALS.join(", ")}"
+          invalid! :invalid_renotify_interval, "renotify_interval must be one of #{RENOTIFY_INTERVALS.join(", ")}"
         end
 
         if ["query alert", "service check"].include?(type) # TODO: most likely more types need this
@@ -240,15 +240,15 @@ module Kennel
         validate_using_links(data)
 
         if type == "service check" && !data[:query].to_s.include?(".by(")
-          invalid! "query must include a .by() at least .by(\"*\")"
+          invalid! :query_must_include_by, "query must include a .by() at least .by(\"*\")"
         end
 
         unless ALLOWED_PRIORITY_CLASSES.include?(priority.class)
-          invalid! "priority needs to be an Integer"
+          invalid! :invalid_priority, "priority needs to be an Integer"
         end
 
         if data.dig(:options, :timeout_h)&.> 24
-          invalid! "timeout_h must be <= 24"
+          invalid! :invalid_timeout_h, "timeout_h must be <= 24"
         end
       end
 
@@ -283,7 +283,7 @@ module Kennel
         forbidden = used - allowed
         return if forbidden.empty?
 
-        invalid! <<~MSG.rstrip
+        invalid! :invalid_variable_used_in_message, <<~MSG.rstrip
           Used #{forbidden.join(", ")} in the message, but can only be used with #{allowed.join(", ")}.
           Group or filter the query by #{forbidden.map { |f| f.sub(".name", "") }.join(", ")} to use it.
         MSG
@@ -295,7 +295,7 @@ module Kennel
           ids = data[:query].tr("-", "_").scan(/\b\d+\b/)
           ids.reject! { |id| ALLOWED_UNLINKED.include?([tracking_id, id]) }
           if ids.any?
-            invalid! <<~MSG.rstrip
+            invalid! :links_must_be_via_tracking_id, <<~MSG.rstrip
               Used #{ids} in the query, but should only use links in the form of %{<project id>:<monitor id>}
               If that is not possible, add `validate_using_links: ->(*){} # linked monitors are not in kennel
             MSG

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -212,7 +212,7 @@ module Kennel
       end
 
       def invalid!(tag, message)
-        unfiltered_validation_errors << ValidationMessage.new(tag, message)
+        unfiltered_validation_errors << ValidationMessage.new(tag || OptionalValidations::UNIGNORABLE, message)
       end
 
       def raise_with_location(error, message)

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -211,8 +211,8 @@ module Kennel
         end
       end
 
-      def invalid!(message)
-        unfiltered_validation_errors << ValidationMessage.new(message)
+      def invalid!(tag, message)
+        unfiltered_validation_errors << ValidationMessage.new(tag, message)
       end
 
       def raise_with_location(error, message)

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -85,7 +85,7 @@ module Kennel
         super
 
         if data[:thresholds].any? { |t| t[:warning] && t[:warning].to_f <= t[:critical].to_f }
-          invalid! "Threshold warning must be greater-than critical value"
+          invalid! :warning_must_be_gt_critical, "Threshold warning must be greater-than critical value"
         end
       end
     end

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -3,9 +3,11 @@ module Kennel
   module OptionalValidations
     ValidationMessage = Struct.new(:tag, :text)
 
+    UNIGNORABLE = :unignorable
+
     def self.included(base)
-      base.settings :validate
-      base.defaults(validate: -> { true })
+      base.settings :ignored_errors
+      base.defaults(ignored_errors: -> { [] })
     end
 
     def self.valid?(parts)
@@ -15,13 +17,25 @@ module Kennel
 
       return true if parts_with_errors.empty?
 
+      example_tag = nil
+
       Kennel.err.puts
       parts_with_errors.sort_by(&:safe_tracking_id).each do |part|
         part.filtered_validation_errors.each do |err|
-          Kennel.err.puts "#{part.safe_tracking_id} #{err.text}"
+          Kennel.err.puts "#{part.safe_tracking_id} [#{err.tag.inspect}] #{err.text.gsub("\n", " ")}"
+          example_tag = err.tag unless err.tag == :unignorable
         end
       end
       Kennel.err.puts
+
+      Kennel.err.puts <<~MESSAGE if example_tag
+        If a particular error cannot be fixed, it can be marked as ignored via `ignored_errors`, e.g.:
+          Kennel::Models::Monitor.new(
+            ...,
+            ignored_errors: [#{example_tag.inspect}]
+          )
+
+      MESSAGE
 
       false
     end
@@ -40,39 +54,30 @@ module Kennel
     end
 
     def filter_validation_errors
-      if validate
-        unfiltered_validation_errors
-      elsif unfiltered_validation_errors.empty?
-        msg = "`validate` is set to false, but there are no validation errors to suppress. Remove `validate: false`"
-
-        mode = ENV.fetch("UNNECESSARY_VALIDATE_FALSE") do
-          if ENV.key?("PROJECT") || ENV.key?("TRACKING_ID")
-            "fail"
-          else
-            nil
-          end
-        end
-
-        if mode == "fail"
-          [ValidationMessage.new(msg)]
-        else
-          Kennel.out.puts "#{safe_tracking_id} #{msg}" if mode == "show"
+      if unfiltered_validation_errors.empty?
+        if ignored_errors.empty?
           []
+        else
+          [ValidationMessage.new(UNIGNORABLE, "`ignored_errors` is non-empty, but there are no errors to ignore. Remove `ignored_errors`")]
         end
       else
-        mode = ENV.fetch("SUPPRESSED_ERRORS", "ignore")
-
-        if mode == "fail"
-          unfiltered_validation_errors
-        else
-          if mode == "show"
-            unfiltered_validation_errors.each do |err|
-              Kennel.out.puts "#{safe_tracking_id} `validate: false` suppressing error: #{err.text.gsub("\n", " ")}"
+        to_report =
+          if ENV["NO_IGNORED_ERRORS"]
+            # Turn off all suppressions, to see what errors are actually being suppressed
+            unfiltered_validation_errors
+          else
+            unfiltered_validation_errors.reject do |err|
+              err.tag != UNIGNORABLE && ignored_errors.include?(err.tag)
             end
           end
 
-          []
+        unused_ignores = ignored_errors - unfiltered_validation_errors.map(&:tag)
+
+        unless unused_ignores.empty?
+          to_report << ValidationMessage.new(UNIGNORABLE, "Unused ignores #{unused_ignores.map(&:inspect).sort.uniq.join(" ")}. Remove these from `ignored_errors`")
         end
+
+        to_report
       end
     end
   end

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Kennel
   module OptionalValidations
-    ValidationMessage = Struct.new(:text)
+    ValidationMessage = Struct.new(:tag, :text)
 
     def self.included(base)
       base.settings :validate
@@ -32,6 +32,7 @@ module Kennel
       bad = Kennel::Utils.all_keys(data).grep_v(Symbol).sort.uniq
       return if bad.empty?
       invalid!(
+        :hash_keys_must_be_symbols,
         "Only use Symbols as hash keys to avoid permanent diffs when updating.\n" \
         "Change these keys to be symbols (usually 'foo' => 1 --> 'foo': 1)\n" \
         "#{bad.map(&:inspect).join("\n")}"

--- a/lib/kennel/template_variables.rb
+++ b/lib/kennel/template_variables.rb
@@ -30,8 +30,7 @@ module Kennel
 
       invalid!(
         :queries_must_use_template_variables,
-        "queries #{queries.join(", ")} must use the template variables #{variables.join(", ")}\n" \
-        "If that is not possible, add `validate: -> { false } # query foo in bar does not have baz tag`"
+        "queries #{queries.join(", ")} must use the template variables #{variables.join(", ")}"
       )
     end
 

--- a/lib/kennel/template_variables.rb
+++ b/lib/kennel/template_variables.rb
@@ -29,6 +29,7 @@ module Kennel
       return if queries.empty?
 
       invalid!(
+        :queries_must_use_template_variables,
         "queries #{queries.join(", ")} must use the template variables #{variables.join(", ")}\n" \
         "If that is not possible, add `validate: -> { false } # query foo in bar does not have baz tag`"
       )

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -59,10 +59,6 @@ describe Kennel::Models::Dashboard do
       dashboard_with_requests.as_json.must_equal expected_json_with_requests
     end
 
-    it "can ignore validations" do
-      dashboard(widgets: -> { [{ definition: { "foo" => 1 } }] }, validate: -> { false }).as_json
-    end
-
     it "complains when datadog would created a diff by sorting template_variable_presets" do
       validation_error_from(dashboard(template_variable_presets: -> { [{ name: "B" }, { name: "A" }] }))
         .must_equal "template_variable_presets must be sorted by name"

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -165,10 +165,6 @@ describe Kennel::Models::Monitor do
         .must_include "query alert"
     end
 
-    it "does not fail when validations are disabled" do
-      monitor(type: -> { "metric alert" }, validate: -> { false }).as_json
-    end
-
     it "sets id when not given" do
       assert_json_equal(
         monitor(id: -> { 123 }).as_json,

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -73,7 +73,7 @@ describe Kennel::Models::Record do
     it "does not throw if build_json throws after a validation error" do
       record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x")
       record.define_singleton_method(:build_json) do
-        invalid! "This is all wrong"
+        invalid! :wrong, "This is all wrong"
         raise "I crashed :-("
       end
       record.build
@@ -84,7 +84,7 @@ describe Kennel::Models::Record do
     it "does not throw if validate_json throws after a validation error" do
       record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x")
       record.define_singleton_method(:validate_json) do |_data|
-        invalid! "This is all wrong"
+        invalid! :wrong, "This is all wrong"
         raise "I crashed :-("
       end
       record.build
@@ -95,8 +95,8 @@ describe Kennel::Models::Record do
     it "is capable of collecting multiple errors" do
       record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x")
       record.define_singleton_method(:validate_json) do |_data|
-        invalid! "one"
-        invalid! "two"
+        invalid! :one, "one"
+        invalid! :two, "two"
       end
       record.build
       record.filtered_validation_errors.map(&:text).must_equal ["one", "two"]
@@ -106,7 +106,7 @@ describe Kennel::Models::Record do
     it "can skip validation entirely" do
       record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x", validate: false)
       record.define_singleton_method(:validate_json) do |_data|
-        invalid! "bang"
+        invalid! :bang, "bang"
       end
       record.build
 
@@ -142,7 +142,7 @@ describe Kennel::Models::Record do
     context "#build finds validation errors" do
       let(:record) do
         r = Kennel::Models::Record.new(TestProject.new, kennel_id: "x", validate: true)
-        r.define_singleton_method(:validate_json) { |_json| invalid! "oh no" }
+        r.define_singleton_method(:validate_json) { |_json| invalid! :oh_no, "oh no" }
         r
       end
 

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -104,7 +104,7 @@ describe Kennel::Models::Record do
     end
 
     it "can skip validation entirely" do
-      record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x", validate: false)
+      record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x", ignored_errors: [:bang])
       record.define_singleton_method(:validate_json) do |_data|
         invalid! :bang, "bang"
       end
@@ -141,7 +141,7 @@ describe Kennel::Models::Record do
 
     context "#build finds validation errors" do
       let(:record) do
-        r = Kennel::Models::Record.new(TestProject.new, kennel_id: "x", validate: true)
+        r = Kennel::Models::Record.new(TestProject.new, kennel_id: "x")
         r.define_singleton_method(:validate_json) { |_json| invalid! :oh_no, "oh no" }
         r
       end
@@ -162,7 +162,7 @@ describe Kennel::Models::Record do
 
     context "build succeeds" do
       let(:record) do
-        Kennel::Models::Record.new(TestProject.new, kennel_id: "x", validate: true)
+        Kennel::Models::Record.new(TestProject.new, kennel_id: "x")
       end
 
       it "does not call build if already built" do

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -12,7 +12,7 @@ describe Kennel::OptionalValidations do
     item = Object.new
     item.extend Kennel::OptionalValidations
     copy_of_errors = errors
-    item.define_singleton_method(:invalid!) do |err|
+    item.define_singleton_method(:invalid!) do |_tag, err|
       copy_of_errors << err
     end
     item
@@ -55,8 +55,8 @@ describe Kennel::OptionalValidations do
         bad(
           "foo",
           [
-            Kennel::OptionalValidations::ValidationMessage.new("your data is bad"),
-            Kennel::OptionalValidations::ValidationMessage.new("and you should feel bad")
+            Kennel::OptionalValidations::ValidationMessage.new(:data, "your data is bad"),
+            Kennel::OptionalValidations::ValidationMessage.new(:you, "and you should feel bad")
           ]
         )
       ]

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative "../test_helper"
 
-SingleCov.covered! uncovered: 19
+SingleCov.covered!
 
 describe Kennel::OptionalValidations do
   with_test_classes
@@ -19,7 +19,8 @@ describe Kennel::OptionalValidations do
   end
 
   it "adds settings" do
-    Kennel::Models::Dashboard.new(TestProject.new, kennel_id: -> { "test" }, validate: -> { false }).validate.must_equal false
+    record = Kennel::Models::Record.new(TestProject.new, kennel_id: -> { "test" }, ignored_errors: -> { [:foo] })
+    record.ignored_errors.must_equal [:foo]
   end
 
   describe ".valid?" do
@@ -50,24 +51,159 @@ describe Kennel::OptionalValidations do
       stderr.string.must_equal ""
     end
 
-    it "runs with a bad part" do
-      parts = [
-        bad(
-          "foo",
-          [
-            Kennel::OptionalValidations::ValidationMessage.new(:data, "your data is bad"),
-            Kennel::OptionalValidations::ValidationMessage.new(:you, "and you should feel bad")
-          ]
-        )
-      ]
-      refute Kennel::OptionalValidations.valid?(parts)
-      stdout.string.must_equal ""
-      stderr.string.must_equal <<~TEXT
+    context "with errors" do
+      it "runs with a bad part" do
+        parts = [
+          bad(
+            "foo",
+            [
+              Kennel::OptionalValidations::ValidationMessage.new(:data, "your data is bad"),
+              Kennel::OptionalValidations::ValidationMessage.new(:you, "and you should feel bad")
+            ]
+          )
+        ]
+        refute Kennel::OptionalValidations.valid?(parts)
+        stdout.string.must_equal ""
+        stderr.string.must_equal <<~TEXT
 
-        foo your data is bad
-        foo and you should feel bad
+          foo [:data] your data is bad
+          foo [:you] and you should feel bad
 
-      TEXT
+          If a particular error cannot be fixed, it can be marked as ignored via `ignored_errors`, e.g.:
+            Kennel::Models::Monitor.new(
+              ...,
+              ignored_errors: [:you]
+            )
+
+        TEXT
+      end
+
+      it "uses the last non-ignorable tag as the example" do
+        parts = [
+          bad(
+            "foo",
+            [
+              Kennel::OptionalValidations::ValidationMessage.new(:data, "your data is bad"),
+              Kennel::OptionalValidations::ValidationMessage.new(:unignorable, "and you should feel bad")
+            ]
+          )
+        ]
+
+        refute Kennel::OptionalValidations.valid?(parts)
+
+        stderr.string.must_include "foo [:unignorable] and you should feel bad"
+        stderr.string.must_include "ignored_errors: [:data]"
+      end
+
+      it "skips the ignored_errors advice is all the errors are unignorable" do
+        parts = [
+          bad(
+            "foo",
+            [
+              Kennel::OptionalValidations::ValidationMessage.new(:unignorable, "your data is bad"),
+              Kennel::OptionalValidations::ValidationMessage.new(:unignorable, "and you should feel bad")
+            ]
+          )
+        ]
+
+        refute Kennel::OptionalValidations.valid?(parts)
+
+        refute_includes stderr.string, "If a particular error cannot be fixed"
+      end
+    end
+  end
+
+  describe "filter_validation_errors" do
+    let(:ignored_errors) { [] }
+
+    let(:item) do
+      Kennel::Models::Record.new(TestProject.new, kennel_id: -> { "test" }, ignored_errors: ignored_errors)
+    end
+
+    context "no validation errors" do
+      it "passes if ignored_errors is empty" do
+        item.build
+        item.filtered_validation_errors.must_be_empty
+      end
+
+      it "fails if ignored_errors is not empty" do
+        ignored_errors << :foo
+        item.build
+        errs = item.filtered_validation_errors
+        errs.length.must_equal 1
+        errs[0].tag.must_equal :unignorable
+        errs[0].text.must_include "there are no errors to ignore"
+      end
+    end
+
+    context "some validation errors" do
+      with_env(NO_IGNORED_ERRORS: nil)
+
+      before do
+        item.define_singleton_method(:validate_json) do |_json|
+          invalid! :x, "Bad juju"
+          invalid! :y, "Worse juju"
+        end
+      end
+
+      it "does not ignore the error" do
+        item.build
+        errs = item.filtered_validation_errors
+        errs.length.must_equal 2
+        errs[0].tag.must_equal :x
+        errs[1].tag.must_equal :y
+      end
+
+      it "can ignore the error" do
+        ignored_errors << :x
+        ignored_errors << :y
+        item.build
+        item.filtered_validation_errors.must_be_empty
+      end
+
+      it "cannot ignore unignorable errors" do
+        item.define_singleton_method(:validate_json) do |_json|
+          invalid! :unignorable, "This is serious"
+        end
+
+        ignored_errors << :unignorable
+
+        item.build
+        errs = item.filtered_validation_errors
+        errs.length.must_equal 1
+        errs[0].tag.must_equal :unignorable
+      end
+
+      it "still reports non-ignored errors" do
+        ignored_errors << :x
+        item.build
+        errs = item.filtered_validation_errors
+        errs.length.must_equal 1
+        errs[0].tag.must_equal :y
+      end
+
+      it "complains if an ignored error didn't happen" do
+        ignored_errors << :x
+        ignored_errors << :y
+        ignored_errors << :zzz
+        item.build
+        errs = item.filtered_validation_errors
+        errs.length.must_equal 1
+        errs[0].tag.must_equal :unignorable
+        errs[0].text.must_include ":zzz"
+      end
+
+      it "reports ignored errors if NO_IGNORED_ERRORS is set" do
+        with_env(NO_IGNORED_ERRORS: "any value") do
+          ignored_errors << :x
+          ignored_errors << :y
+          item.build
+          errs = item.filtered_validation_errors
+          errs.length.must_equal 2
+          errs[0].tag.must_equal :x
+          errs[1].tag.must_equal :y
+        end
+      end
     end
   end
 

--- a/test/kennel/template_variables_test.rb
+++ b/test/kennel/template_variables_test.rb
@@ -35,7 +35,7 @@ describe Kennel::TemplateVariables do
       item = Object.new
       item.extend Kennel::TemplateVariables
       copy_of_errors = errors
-      item.define_singleton_method(:invalid!) do |err|
+      item.define_singleton_method(:invalid!) do |_tag, err|
         copy_of_errors << err
       end
       item


### PR DESCRIPTION
Supersedes https://github.com/zdrve/kennel/pull/4 and https://github.com/grosser/kennel/pull/212 .

This PR *removes* the `validate` setting and replaces it with `ignored_errors`. Also, the call signature to `invalid!` changes to two arguments – a tag (may be nil, which means "unignorable"), then a message.

So the corresponding z-kennel-config branch will need to accommodate those two changes. 
