### PR TITLE
ignore new duplicate slo attributes datadog emits

### DIFF
--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -2,7 +2,7 @@
 module Kennel
   module Models
     class Slo < Record
-      READONLY_ATTRIBUTES = superclass::READONLY_ATTRIBUTES + [:type_id, :monitor_tags]
+      READONLY_ATTRIBUTES = superclass::READONLY_ATTRIBUTES + [:type_id, :monitor_tags, :target_threshold, :timeframe, :warning_threshold]
       TRACKING_FIELD = :description
       DEFAULTS = {
         description: nil,


### PR DESCRIPTION
somehow they are now in the api response but are not needed to update a monitor :/
... results in permanent diff for all slos