### PR TITLE
parallel download: enable plain when needed

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -59,7 +59,7 @@ module Kennel
     attr_accessor :strict_imports
 
     def generate
-      parts = generated(plain: false)
+      parts = generated
       parts_serializer.write(parts) if ENV["STORE"] != "false" # quicker when debugging
       parts
     end
@@ -75,8 +75,8 @@ module Kennel
 
     private
 
-    def download_definitions
-      Progress.progress("Downloading definitions", plain: true) do
+    def download_definitions(**kwargs)
+      Progress.progress("Downloading definitions", **kwargs) do
         Utils.parallel(Models::Record.subclasses) do |klass|
           results = api.list(klass.api_resource, with_downtimes: false) # lookup monitors without adding unnecessary downtime information
           results.each { |a| Utils.inline_resource_metadata(a, klass) }
@@ -90,7 +90,7 @@ module Kennel
 
     def syncer
       @syncer ||= begin
-        expected, actual = Utils.parallel([:generated, :download_definitions]) { |m| send m }
+        expected, actual = Utils.parallel([:generated, :download_definitions]) { |m| send m, plain: true }
         Syncer.new(api, expected, actual, kennel: self, project_filter: filter.project_filter, tracking_id_filter: filter.tracking_id_filter)
       end
     end
@@ -107,9 +107,9 @@ module Kennel
       @parts_serializer ||= PartsSerializer.new(filter: filter)
     end
 
-    def generated(plain: true)
+    def generated(**kwargs)
       @generated ||= begin
-        parts = Progress.progress "Finding parts", plain: plain do
+        parts = Progress.progress "Finding parts", **kwargs do
           projects = projects_provider.projects
           projects = filter.filter_projects projects
 

--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -101,6 +101,7 @@ namespace :kennel do
   end
 
   # also generate parts so users see and commit updated generated automatically
+  # (generate must run after plan to enable parallel .download+.generate inside of .plan)
   desc "show planned datadog changes (scope with PROJECT=name)"
   task plan: :environment do
     Kennel::Tasks.kennel.plan


### PR DESCRIPTION
looked over the logic again and it seems a bit complicated ...
hope this is simpler "turn on plain when needed" instead of "some parts run in plain by default"