### PR TITLE
Builder vs Built

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -30,6 +30,12 @@ require "kennel/models/monitor"
 require "kennel/models/slo"
 require "kennel/models/synthetic_test"
 
+require 'kennel/models/built/record'
+require 'kennel/models/built/dashboard'
+require 'kennel/models/built/monitor'
+require 'kennel/models/built/slo'
+require 'kennel/models/built/synthetic_test'
+
 # settings
 require "kennel/models/project"
 require "kennel/models/team"
@@ -121,7 +127,7 @@ module Kennel
           ERROR
         end
 
-        Progress.progress "Building json" do
+        parts = Progress.progress "Building json" do
           # trigger json caching here so it counts into generating
           Utils.parallel(parts, &:build)
         end

--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -30,11 +30,11 @@ require "kennel/models/monitor"
 require "kennel/models/slo"
 require "kennel/models/synthetic_test"
 
-require 'kennel/models/built/record'
-require 'kennel/models/built/dashboard'
-require 'kennel/models/built/monitor'
-require 'kennel/models/built/slo'
-require 'kennel/models/built/synthetic_test'
+require "kennel/models/built/record"
+require "kennel/models/built/dashboard"
+require "kennel/models/built/monitor"
+require "kennel/models/built/slo"
+require "kennel/models/built/synthetic_test"
 
 # settings
 require "kennel/models/project"

--- a/lib/kennel/models/built/dashboard.rb
+++ b/lib/kennel/models/built/dashboard.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Kennel
+  module Models
+    module Built
+      class Dashboard < Record
+        def resolve_linked_tracking_ids!(id_map, **args)
+          widgets = as_json[:widgets].flat_map { |w| [w, *w.dig(:definition, :widgets) || []] }
+          widgets.each do |widget|
+            next unless definition = widget[:definition]
+            case definition[:type]
+            when "uptime"
+              if ids = definition[:monitor_ids]
+                definition[:monitor_ids] = ids.map do |id|
+                  resolve(id, :monitor, id_map, **args) || id
+                end
+              end
+            when "alert_graph"
+              if id = definition[:alert_id]
+                resolved = resolve(id, :monitor, id_map, **args) || id
+                definition[:alert_id] = resolved.to_s # even though it's a monitor id
+              end
+            when "slo"
+              if id = definition[:slo_id]
+                definition[:slo_id] = resolve(id, :slo, id_map, **args) || id
+              end
+            end
+          end
+        end
+
+        def validate_update!(_actuals, diffs)
+          _, path, from, to = diffs.find { |diff| diff[1] == "layout_type" }
+          invalid_update!(path, from, to) if path
+        end
+      end
+    end
+  end
+end

--- a/lib/kennel/models/built/monitor.rb
+++ b/lib/kennel/models/built/monitor.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Kennel
+  module Models
+    module Built
+      class Monitor < Record
+        def resolve_linked_tracking_ids!(id_map, **args)
+          case as_json[:type]
+          when "composite", "slo alert"
+            type = (as_json[:type] == "composite" ? :monitor : :slo)
+            as_json[:query] = as_json[:query].gsub(/%{(.*?)}/) do
+              resolve($1, type, id_map, **args) || $&
+            end
+          else # do nothing
+          end
+        end
+
+        def validate_update!(_actuals, diffs)
+          # ensure type does not change, but not if it's metric->query which is supported and used by importer.rb
+          _, path, from, to = diffs.detect { |_, path, _, _| path == "type" }
+          if path && !(from == "metric alert" && to == "query alert")
+            invalid_update!(path, from, to)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kennel/models/built/record.rb
+++ b/lib/kennel/models/built/record.rb
@@ -78,8 +78,8 @@ module Kennel
           if id_map.new?(sought_type.to_s, sought_tracking_id)
             if force
               raise UnresolvableIdError, <<~MESSAGE
-              #{tracking_id} #{sought_type} #{sought_tracking_id} was referenced but is also created by the current run.
-              It could not be created because of a circular dependency. Try creating only some of the resources.
+                #{tracking_id} #{sought_type} #{sought_tracking_id} was referenced but is also created by the current run.
+                It could not be created because of a circular dependency. Try creating only some of the resources.
               MESSAGE
             else
               nil # will be re-resolved after the linked object was created
@@ -88,9 +88,9 @@ module Kennel
             id
           else
             raise UnresolvableIdError, <<~MESSAGE
-            #{tracking_id} Unable to find #{sought_type} #{sought_tracking_id}
-            This is either because it doesn't exist, and isn't being created by the current run;
-            or it does exist, but is being deleted.
+              #{tracking_id} Unable to find #{sought_type} #{sought_tracking_id}
+              This is either because it doesn't exist, and isn't being created by the current run;
+              or it does exist, but is being deleted.
             MESSAGE
           end
         end

--- a/lib/kennel/models/built/record.rb
+++ b/lib/kennel/models/built/record.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Kennel
+  module Models
+    module Built
+      class Record
+        def initialize(
+          as_json:,
+          project:,
+          unbuilt_class:,
+          tracking_id:,
+          id:,
+          unfiltered_validation_errors:
+        )
+          @as_json = as_json
+          @project = project
+          @unbuilt_class = unbuilt_class
+          @tracking_id = tracking_id.freeze
+          @id = id.freeze
+          @unfiltered_validation_errors = unfiltered_validation_errors
+        end
+
+        attr_reader :as_json, :project, :unbuilt_class, :tracking_id, :id, :unfiltered_validation_errors
+
+        def filtered_validation_errors
+          []
+        end
+
+        # Can raise DisallowedUpdateError
+        def validate_update!(*)
+        end
+
+        def invalid_update!(field, old_value, new_value)
+          raise DisallowedUpdateError, "#{tracking_id} Datadog does not allow update of #{field} (#{old_value.inspect} -> #{new_value.inspect})"
+        end
+
+        def diff(actual)
+          expected = as_json
+          expected.delete(:id)
+
+          unbuilt_class.normalize(expected, actual)
+
+          # strict: ignore Integer vs Float
+          # similarity: show diff when not 100% similar
+          # use_lcs: saner output
+          Hashdiff.diff(actual, expected, use_lcs: false, strict: false, similarity: 1)
+        end
+
+        def resolve_linked_tracking_ids!(*)
+        end
+
+        def add_tracking_id
+          json = as_json
+          if unbuilt_class.parse_tracking_id(json)
+            raise "#{tracking_id} Remove \"-- #{unbuilt_class::MARKER_TEXT}\" line from #{unbuilt_class::TRACKING_FIELD} to copy a resource"
+          end
+          json[unbuilt_class::TRACKING_FIELD] =
+            "#{json[unbuilt_class::TRACKING_FIELD]}\n" \
+          "-- #{unbuilt_class::MARKER_TEXT} #{tracking_id} in #{project.class.file_location}, do not modify manually".lstrip
+        end
+
+        def remove_tracking_id
+          unbuilt_class.remove_tracking_id(as_json)
+        end
+
+        def resolve(value, type, id_map, force:)
+          return value unless tracking_id?(value)
+          resolve_link(value, type, id_map, force: force)
+        end
+
+        private
+
+        def tracking_id?(id)
+          id.is_a?(String) && id.include?(":")
+        end
+
+        def resolve_link(sought_tracking_id, sought_type, id_map, force:)
+          if id_map.new?(sought_type.to_s, sought_tracking_id)
+            if force
+              raise UnresolvableIdError, <<~MESSAGE
+              #{tracking_id} #{sought_type} #{sought_tracking_id} was referenced but is also created by the current run.
+              It could not be created because of a circular dependency. Try creating only some of the resources.
+              MESSAGE
+            else
+              nil # will be re-resolved after the linked object was created
+            end
+          elsif id = id_map.get(sought_type.to_s, sought_tracking_id)
+            id
+          else
+            raise UnresolvableIdError, <<~MESSAGE
+            #{tracking_id} Unable to find #{sought_type} #{sought_tracking_id}
+            This is either because it doesn't exist, and isn't being created by the current run;
+            or it does exist, but is being deleted.
+            MESSAGE
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kennel/models/built/slo.rb
+++ b/lib/kennel/models/built/slo.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Kennel
+  module Models
+    module Built
+      class Slo < Record
+        def resolve_linked_tracking_ids!(id_map, **args)
+          return unless ids = as_json[:monitor_ids] # ignore_default can remove it
+          as_json[:monitor_ids] = ids.map do |id|
+            resolve(id, :monitor, id_map, **args) || id
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kennel/models/built/synthetic_test.rb
+++ b/lib/kennel/models/built/synthetic_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Kennel
+  module Models
+    module Built
+      class SyntheticTest < Record
+      end
+    end
+  end
+end

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -90,6 +90,10 @@ module Kennel
       )
 
       class << self
+        def built_class
+          Built::Dashboard
+        end
+
         def api_resource
           "dashboard"
         end
@@ -176,35 +180,6 @@ module Kennel
 
       def self.parse_url(url)
         url[/\/dashboard\/([a-z\d-]+)/, 1]
-      end
-
-      def resolve_linked_tracking_ids!(id_map, **args)
-        widgets = as_json[:widgets].flat_map { |w| [w, *w.dig(:definition, :widgets) || []] }
-        widgets.each do |widget|
-          next unless definition = widget[:definition]
-          case definition[:type]
-          when "uptime"
-            if ids = definition[:monitor_ids]
-              definition[:monitor_ids] = ids.map do |id|
-                resolve(id, :monitor, id_map, **args) || id
-              end
-            end
-          when "alert_graph"
-            if id = definition[:alert_id]
-              resolved = resolve(id, :monitor, id_map, **args) || id
-              definition[:alert_id] = resolved.to_s # even though it's a monitor id
-            end
-          when "slo"
-            if id = definition[:slo_id]
-              definition[:slo_id] = resolve(id, :slo, id_map, **args) || id
-            end
-          end
-        end
-      end
-
-      def validate_update!(_actuals, diffs)
-        _, path, from, to = diffs.find { |diff| diff[1] == "layout_type" }
-        invalid_update!(path, from, to) if path
       end
 
       private

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -126,23 +126,8 @@ module Kennel
         data
       end
 
-      def resolve_linked_tracking_ids!(id_map, **args)
-        case as_json[:type]
-        when "composite", "slo alert"
-          type = (as_json[:type] == "composite" ? :monitor : :slo)
-          as_json[:query] = as_json[:query].gsub(/%{(.*?)}/) do
-            resolve($1, type, id_map, **args) || $&
-          end
-        else # do nothing
-        end
-      end
-
-      def validate_update!(_actuals, diffs)
-        # ensure type does not change, but not if it's metric->query which is supported and used by importer.rb
-        _, path, from, to = diffs.detect { |_, path, _, _| path == "type" }
-        if path && !(from == "metric alert" && to == "query alert")
-          invalid_update!(path, from, to)
-        end
+      def self.built_class
+        Built::Monitor
       end
 
       def self.api_resource

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -125,7 +125,7 @@ module Kennel
         rescue StandardError
           if unfiltered_validation_errors.empty?
             @unfiltered_validation_errors = nil
-            raise PrepareError, safe_tracking_id
+            raise PrepareError, safe_tracking_id + " because of " + $!.to_s + " at " + $!.backtrace.inspect
           end
         end
 
@@ -150,6 +150,7 @@ module Kennel
         end
       end
 
+      # Useful for the test suite
       def build!
         build.tap do |result|
           if result.is_a?(InvalidPart)

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -44,6 +44,10 @@ module Kennel
         data
       end
 
+      def self.built_class
+        Built::Slo
+      end
+
       def self.api_resource
         "slo"
       end
@@ -54,13 +58,6 @@ module Kennel
 
       def self.parse_url(url)
         url[/\/slo(\?.*slo_id=|\/edit\/)([a-z\d]{10,})(&|$)/, 2]
-      end
-
-      def resolve_linked_tracking_ids!(id_map, **args)
-        return unless ids = as_json[:monitor_ids] # ignore_default can remove it
-        as_json[:monitor_ids] = ids.map do |id|
-          resolve(id, :monitor, id_map, **args) || id
-        end
       end
 
       def self.normalize(expected, actual)

--- a/lib/kennel/models/synthetic_test.rb
+++ b/lib/kennel/models/synthetic_test.rb
@@ -30,6 +30,10 @@ module Kennel
         )
       end
 
+      def self.built_class
+        Built::SyntheticTest
+      end
+
       def self.api_resource
         "synthetics/tests"
       end

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -20,9 +20,9 @@ module Kennel
       example_tag = nil
 
       Kennel.err.puts
-      parts_with_errors.sort_by(&:safe_tracking_id).each do |part|
+      parts_with_errors.sort_by(&:tracking_id).each do |part|
         part.filtered_validation_errors.each do |err|
-          Kennel.err.puts "#{part.safe_tracking_id} [#{err.tag.inspect}] #{err.text.gsub("\n", " ")}"
+          Kennel.err.puts "#{part.tracking_id} [#{err.tag.inspect}] #{err.text.gsub("\n", " ")}"
           example_tag = err.tag unless err.tag == :unignorable
         end
       end

--- a/lib/kennel/parts_serializer.rb
+++ b/lib/kennel/parts_serializer.rb
@@ -31,7 +31,7 @@ module Kennel
         used << File.dirname(path) # only 1 level of sub folders, so this is enough
         used << path
 
-        payload = part.as_json.merge(api_resource: part.class.api_resource)
+        payload = part.as_json.merge(api_resource: part.unbuilt_class.api_resource)
         write_file_if_necessary(path, JSON.pretty_generate(payload) << "\n")
       end
 

--- a/lib/kennel/subclass_tracking.rb
+++ b/lib/kennel/subclass_tracking.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Kennel
   module SubclassTracking
-    TRACKED_CLASSES = []
+    @@tracked_classes = []
 
     def recursive_subclasses
       subclasses + subclasses.flat_map(&:recursive_subclasses)
@@ -15,7 +15,7 @@ module Kennel
 
     def inherited(child)
       super
-      TRACKED_CLASSES << child
+      @@tracked_classes << child
       subclasses << child
     end
   end

--- a/lib/kennel/subclass_tracking.rb
+++ b/lib/kennel/subclass_tracking.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Kennel
   module SubclassTracking
+    TRACKED_CLASSES = []
+
     def recursive_subclasses
       subclasses + subclasses.flat_map(&:recursive_subclasses)
     end
@@ -13,6 +15,7 @@ module Kennel
 
     def inherited(child)
       super
+      TRACKED_CLASSES << child
       subclasses << child
     end
   end

--- a/test/kennel/models/built/dashboard_test.rb
+++ b/test/kennel/models/built/dashboard_test.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+require_relative "../../../test_helper"
+
+SingleCov.covered!
+
+describe Kennel::Models::Built::Dashboard do
+  with_test_classes
+
+  let(:project) { TestProject.new }
+  let(:id_map) { Kennel::IdMap.new }
+
+  def dashboard(extra = {})
+    Kennel::Models::Dashboard.new(project, { kennel_id: 'd', title: -> { "Hello" }, layout_type: -> { "ordered" } }.merge(extra))
+  end
+
+  let(:dashboard_with_requests) do
+    dashboard(
+      widgets: -> { [{ definition: { requests: [{ q: "foo", display_type: "area" }], type: "timeseries", title: "bar" } }] }
+    )
+  end
+
+  describe "#resolve_linked_tracking_ids" do
+    let(:built) { dashboard_with_requests.build! }
+    let(:definition) { built.as_json[:widgets][0][:definition] }
+
+    def resolve(force: false)
+      built.resolve_linked_tracking_ids!(id_map, force: force)
+      built.as_json[:widgets][0][:definition]
+    end
+
+    it "does nothing for regular widgets" do
+      resolve.keys.must_equal [:requests, :type, :title]
+    end
+
+    it "ignores widgets without definition" do
+      built.as_json[:widgets][0].delete :definition
+      resolve.must_be_nil
+    end
+
+    describe "uptime" do
+      before { definition[:type] = "uptime" }
+
+      it "does not change without monitor" do
+        refute resolve.key?(:monitor_ids)
+      end
+
+      it "does not change with id" do
+        definition[:monitor_ids] = [123]
+        resolve[:monitor_ids].must_equal [123]
+      end
+
+      it "resolves full id" do
+        definition[:monitor_ids] = ["#{project.kennel_id}:b"]
+        id_map.set("monitor", "a:c", 1)
+        id_map.set("monitor", "#{project.kennel_id}:b", 123)
+        resolved = resolve
+        resolved[:monitor_ids].must_equal [123]
+      end
+
+      it "fail hard when id is still missing after dependent monitors were created by syncer" do
+        definition[:monitor_ids] = ["missing:the_id"]
+        id_map.set("monitor", "missing:the_id", Kennel::IdMap::NEW)
+        e = assert_raises Kennel::UnresolvableIdError do
+          resolve(force: true)
+        end
+        e.message.must_include "circular dependency"
+      end
+    end
+
+    describe "alert_graph" do
+      before { definition[:type] = "alert_graph" }
+
+      it "does not change the alert widget without monitor" do
+        refute resolve.key?(:alert_id)
+      end
+
+      it "does not change the alert widget with a string encoded id" do
+        definition[:alert_id] = "123"
+        resolve[:alert_id].must_equal "123"
+      end
+
+      it "resolves the alert widget with full id" do
+        definition[:alert_id] = "#{project.kennel_id}:b"
+        id_map.set("monitor", "a:c", 1)
+        id_map.set("monitor", "#{project.kennel_id}:b", 123)
+        resolved = resolve
+        resolved[:alert_id].must_equal "123"
+      end
+
+      it "does not fail hard when id is missing to not break when adding new monitors" do
+        definition[:alert_id] = "a:b"
+        id_map.set("monitor", "a:b", Kennel::IdMap::NEW)
+        resolve[:alert_id].must_equal "a:b"
+      end
+    end
+
+    describe "slo" do
+      before { definition[:type] = "slo" }
+
+      it "does not modify regular ids" do
+        definition[:slo_id] = "abcdef1234567"
+        resolve[:slo_id].must_equal "abcdef1234567"
+      end
+
+      it "resolves the slo widget with full id" do
+        definition[:slo_id] = "#{project.kennel_id}:b"
+        id_map.set("slo", "a:c", "1")
+        id_map.set("slo", "#{project.kennel_id}:b", "123")
+        resolved = resolve
+        resolved[:slo_id].must_equal "123"
+      end
+
+      it "resolves nested slo widget with full id" do
+        definition[:widgets] = [{ definition: { slo_id: "#{project.kennel_id}:b", type: "slo" } }]
+        id_map.set("slo", "a:c", "1")
+        id_map.set("slo", "#{project.kennel_id}:b", "123")
+        resolved = resolve
+        resolved[:widgets][0][:definition][:slo_id].must_equal "123"
+      end
+    end
+  end
+
+  describe "#validate_update!" do
+    it "allows update of title" do
+      dashboard.build!.validate_update!(nil, [["~", "title", "foo", "bar"]])
+    end
+
+    it "disallows update of layout_type" do
+      e = assert_raises Kennel::DisallowedUpdateError do
+        dashboard.build!.validate_update!(nil, [["~", "layout_type", "foo", "bar"]])
+      end
+      e.message.must_match(/datadog.*allow.*layout_type/i)
+    end
+  end
+end

--- a/test/kennel/models/built/dashboard_test.rb
+++ b/test/kennel/models/built/dashboard_test.rb
@@ -10,7 +10,7 @@ describe Kennel::Models::Built::Dashboard do
   let(:id_map) { Kennel::IdMap.new }
 
   def dashboard(extra = {})
-    Kennel::Models::Dashboard.new(project, { kennel_id: 'd', title: -> { "Hello" }, layout_type: -> { "ordered" } }.merge(extra))
+    Kennel::Models::Dashboard.new(project, { kennel_id: "d", title: -> { "Hello" }, layout_type: -> { "ordered" } }.merge(extra))
   end
 
   let(:dashboard_with_requests) do

--- a/test/kennel/models/built/monitor_test.rb
+++ b/test/kennel/models/built/monitor_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+require_relative "../../../test_helper"
+
+SingleCov.covered!
+
+describe Kennel::Models::Built::Monitor do
+  with_test_classes
+
+  def monitor(options = {})
+    Kennel::Models::Monitor.new(
+      options.delete(:project) || project,
+      {
+        type: -> { "query alert" },
+        kennel_id: -> { "m1" },
+        query: -> { "avg(last_5m) > #{critical}" },
+        critical: -> { 123.0 }
+      }.merge(options)
+    )
+  end
+
+  let(:project) { TestProject.new }
+  let(:id_map) { Kennel::IdMap.new }
+
+  describe "#resolve_linked_tracking_ids" do
+    let(:mon) do
+      monitor(query: -> { "%{#{project.kennel_id}:mon}" }).build!
+    end
+
+    it "does nothing for regular monitors" do
+      mon.resolve_linked_tracking_ids!(id_map, force: false)
+      mon.as_json[:query].must_equal "%{#{project.kennel_id}:mon}"
+    end
+
+    describe "composite monitor" do
+      let(:mon) do
+        monitor(type: -> { "composite" }, query: -> { "%{foo:mon_a} || !%{bar:mon_b}" }).build!
+      end
+
+      it "fails when matching monitor is missing" do
+        e = assert_raises Kennel::UnresolvableIdError do
+          mon.resolve_linked_tracking_ids!(id_map, force: false)
+        end
+        e.message.must_include "test_project:m1 Unable to find monitor foo:mon_a"
+      end
+
+      it "does not fail when unable to try to resolve" do
+        id_map.set("monitor", "foo:mon_a", Kennel::IdMap::NEW)
+        id_map.set("monitor", "bar:mon_b", Kennel::IdMap::NEW)
+        mon.resolve_linked_tracking_ids!(id_map, force: false)
+        mon.as_json[:query].must_equal "%{foo:mon_a} || !%{bar:mon_b}", "query not modified"
+      end
+
+      it "resolves correctly with a matching monitor" do
+        id_map.set("monitor", "foo:mon_x", 3)
+        id_map.set("monitor", "foo:mon_a", 1)
+        id_map.set("monitor", "bar:mon_b", 2)
+        mon.resolve_linked_tracking_ids!(id_map, force: false)
+        mon.as_json[:query].must_equal("1 || !2")
+      end
+    end
+
+    describe "slo alert monitor" do
+      let(:mon) do
+        monitor(type: -> { "slo alert" }, query: -> { "error_budget(\"%{foo:slo_a}\").over(\"7d\") > #{critical}" }).build!
+      end
+
+      it "fails when matching monitor is missing" do
+        e = assert_raises Kennel::UnresolvableIdError do
+          mon.resolve_linked_tracking_ids!(id_map, force: false)
+        end
+        e.message.must_include "test_project:m1 Unable to find slo foo:slo_a"
+      end
+
+      it "resolves correctly with a matching monitor" do
+        id_map.set("slo", "foo:slo_x", "3")
+        id_map.set("slo", "foo:slo_a", "1")
+        id_map.set("slo", "foo:slo_b", "2")
+        mon.resolve_linked_tracking_ids!(id_map, force: false)
+        mon.as_json[:query].must_equal("error_budget(\"1\").over(\"7d\") > 123.0")
+      end
+    end
+  end
+
+  describe "#validate_update!" do
+    it "allows update of name" do
+      monitor.build!.validate_update!(nil, [["~", "name", "foo", "bar"]])
+    end
+
+    it "disallows update of type" do
+      e = assert_raises Kennel::DisallowedUpdateError do
+        monitor.build!.validate_update!(nil, [["~", "type", "foo", "bar"]])
+      end
+      e.message.must_match(/datadog.*allow.*type/i)
+    end
+
+    it "allows update of metric to query which is used by the importer" do
+      monitor.build!.validate_update!(nil, [["~", "type", "metric alert", "query alert"]])
+    end
+  end
+end

--- a/test/kennel/models/built/record_test.rb
+++ b/test/kennel/models/built/record_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+require_relative "../../../test_helper"
+
+SingleCov.covered!
+
+describe Kennel::Models::Built::Record do
+  with_test_classes
+
+  let(:built) {
+    Kennel::Models::Built::Monitor.new(
+      as_json: { message: "Some text" },
+      project: TestProject.new,
+      unbuilt_class: Kennel::Models::Monitor,
+      tracking_id: "test_project:test",
+      id: nil,
+      unfiltered_validation_errors: []
+    )
+  }
+
+  let(:id_map) { Kennel::IdMap.new }
+
+  it "has no errors" do
+    built.filtered_validation_errors.must_be_empty
+  end
+
+  describe "#resolve" do
+    it "lets non-tracking-ids through unchanged" do
+      built.resolve("foobar", :slo, id_map, force: false).must_equal "foobar"
+    end
+
+    it "resolves existing" do
+      id_map.set("monitor", "foo:bar", 2)
+      id_map.set("monitor", "foo:bar", 2)
+      built.resolve("foo:bar", :monitor, id_map, force: false).must_equal 2
+    end
+
+    it "warns when trying to resolve" do
+      id_map.set("monitor", "foo:bar", Kennel::IdMap::NEW)
+      built.resolve("foo:bar", :monitor, id_map, force: false).must_be_nil
+    end
+
+    it "fails when forcing resolve because of a circular dependency" do
+      id_map.set("monitor", "foo:bar", Kennel::IdMap::NEW)
+      e = assert_raises Kennel::UnresolvableIdError do
+        built.resolve("foo:bar", :monitor, id_map, force: true)
+      end
+      e.message.must_include "circular dependency"
+    end
+
+    it "fails when trying to resolve but it is unresolvable" do
+      id_map.set("monitor", "foo:bar", 1)
+      e = assert_raises Kennel::UnresolvableIdError do
+        built.resolve("foo:xyz", :monitor, id_map, force: false)
+      end
+      e.message.must_include "test_project:test Unable to find monitor foo:xyz"
+    end
+  end
+
+  describe "#add_tracking_id" do
+    it "adds" do
+      built.as_json[:message].wont_include "kennel"
+      built.add_tracking_id
+      built.as_json[:message].must_include "kennel"
+    end
+
+    it "fails when it would have been added twice (user already added it by mistake)" do
+      built.add_tracking_id
+      assert_raises(RuntimeError) { built.add_tracking_id }.message.must_include("to copy a resource")
+    end
+  end
+
+  describe "#remove_tracking_id" do
+    it "removes" do
+      old = built.as_json[:message].dup
+      built.add_tracking_id
+      built.remove_tracking_id
+      built.as_json[:message].must_equal old
+    end
+  end
+
+  describe "#invalid_update!" do
+    it "raises the right error" do
+      error = assert_raises(Kennel::DisallowedUpdateError) { built.invalid_update!(:foo, "bar", "baz") }
+      error.message.must_equal("#{built.tracking_id} Datadog does not allow update of foo (\"bar\" -> \"baz\")")
+    end
+  end
+
+  describe "#diff" do
+    # minitest defines diff, do not override it
+    def diff_resource(e, a)
+      default = { tags: [] }
+      b = Kennel::Models::Built::Record.new(
+        as_json: default.merge(e),
+        project: TestProject.new,
+        unbuilt_class: Kennel::Models::Record,
+        tracking_id: "a:b",
+        id: nil,
+        unfiltered_validation_errors: [],
+      )
+      b.diff(default.merge(a))
+    end
+
+    it "is empty when empty" do
+      diff_resource({}, {}).must_equal []
+    end
+
+    it "ignores readonly attributes" do
+      diff_resource({}, deleted: true).must_equal []
+    end
+
+    it "ignores ids" do
+      diff_resource({ id: 123 }, id: 234).must_equal []
+    end
+
+    it "ignores klass attribute that syncer adds" do
+      diff_resource({}, klass: String).must_equal []
+    end
+
+    it "makes tag diffs look neat" do
+      diff_resource({ tags: ["a", "b"] }, tags: ["b", "c"]).must_equal([["~", "tags[0]", "b", "a"], ["~", "tags[1]", "c", "b"]])
+    end
+
+    it "makes graph diffs look neat" do
+      diff_resource({ graphs: [{ requests: [{ foo: "bar" }] }] }, graphs: [{ requests: [{ foo: "baz" }] }]).must_equal(
+        [["~", "graphs[0].requests[0].foo", "baz", "bar"]]
+      )
+    end
+
+    it "ignores numeric class difference since the api is semi random on these" do
+      diff_resource({ a: 1 }, a: 1.0).must_equal []
+    end
+  end
+end

--- a/test/kennel/models/built/record_test.rb
+++ b/test/kennel/models/built/record_test.rb
@@ -6,7 +6,7 @@ SingleCov.covered!
 describe Kennel::Models::Built::Record do
   with_test_classes
 
-  let(:built) {
+  let(:built) do
     Kennel::Models::Built::Monitor.new(
       as_json: { message: "Some text" },
       project: TestProject.new,
@@ -15,7 +15,7 @@ describe Kennel::Models::Built::Record do
       id: nil,
       unfiltered_validation_errors: []
     )
-  }
+  end
 
   let(:id_map) { Kennel::IdMap.new }
 
@@ -95,7 +95,7 @@ describe Kennel::Models::Built::Record do
         unbuilt_class: Kennel::Models::Record,
         tracking_id: "a:b",
         id: nil,
-        unfiltered_validation_errors: [],
+        unfiltered_validation_errors: []
       )
       b.diff(default.merge(a))
     end

--- a/test/kennel/models/built/slo_test.rb
+++ b/test/kennel/models/built/slo_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require_relative "../../../test_helper"
+
+SingleCov.covered!
+
+describe Kennel::Models::Built::Slo do
+  with_test_classes
+
+  def slo(options = {})
+    Kennel::Models::Slo.new(
+      options.delete(:project) || project,
+      {
+        type: -> { "metric" },
+        name: -> { "Foo" },
+        kennel_id: -> { "m1" }
+      }.merge(options)
+    )
+  end
+
+  let(:project) { TestProject.new }
+  let(:id_map) { Kennel::IdMap.new }
+
+  describe "#resolve_linked_tracking_ids!" do
+    it "ignores empty caused by ignore_default" do
+      slo = slo(monitor_ids: -> { nil }).build!
+      slo.resolve_linked_tracking_ids!(id_map, force: false)
+      refute slo.as_json[:monitor_ids]
+    end
+
+    it "does nothing for hardcoded ids" do
+      slo = slo(monitor_ids: -> { [123] }).build!
+      slo.resolve_linked_tracking_ids!(id_map, force: false)
+      slo.as_json[:monitor_ids].must_equal [123]
+    end
+
+    it "resolves relative ids" do
+      slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] }).build!
+      id_map.set("monitor", "#{project.kennel_id}:mon", 123)
+      slo.resolve_linked_tracking_ids!(id_map, force: false)
+      slo.as_json[:monitor_ids].must_equal [123]
+    end
+
+    it "does not resolve missing ids so they can resolve when monitor was created" do
+      slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] }).build!
+      id_map.set("monitor", "#{project.kennel_id}:mon", Kennel::IdMap::NEW)
+      slo.resolve_linked_tracking_ids!(id_map, force: false)
+      slo.as_json[:monitor_ids].must_equal ["test_project:mon"]
+    end
+
+    it "fails with typos" do
+      slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] }).build!
+      assert_raises Kennel::UnresolvableIdError do
+        slo.resolve_linked_tracking_ids!(id_map, force: false)
+      end
+    end
+  end
+end

--- a/test/kennel/models/built/synthetic_test_test.rb
+++ b/test/kennel/models/built/synthetic_test_test.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require_relative "../../../test_helper"
+
+SingleCov.covered!
+
+describe Kennel::Models::Built::SyntheticTest do
+end

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -14,7 +14,6 @@ describe Kennel::Models::Dashboard do
   end
 
   let(:project) { TestProject.new }
-  let(:id_map) { Kennel::IdMap.new }
   let(:expected_json) do
     {
       layout_type: "ordered",
@@ -132,107 +131,6 @@ describe Kennel::Models::Dashboard do
         assert_raises prepare_error_of(ArgumentError) do
           dashboard(definitions: -> { [["bar", "timeseries", "area", "foo", { a: 1 }]] }).build!.as_json
         end
-      end
-    end
-  end
-
-  describe "#resolve_linked_tracking_ids" do
-    let(:built) { dashboard_with_requests.build! }
-    let(:definition) { built.as_json[:widgets][0][:definition] }
-
-    def resolve(force: false)
-      built.resolve_linked_tracking_ids!(id_map, force: force)
-      built.as_json[:widgets][0][:definition]
-    end
-
-    it "does nothing for regular widgets" do
-      resolve.keys.must_equal [:requests, :type, :title]
-    end
-
-    it "ignores widgets without definition" do
-      built.as_json[:widgets][0].delete :definition
-      resolve.must_be_nil
-    end
-
-    describe "uptime" do
-      before { definition[:type] = "uptime" }
-
-      it "does not change without monitor" do
-        refute resolve.key?(:monitor_ids)
-      end
-
-      it "does not change with id" do
-        definition[:monitor_ids] = [123]
-        resolve[:monitor_ids].must_equal [123]
-      end
-
-      it "resolves full id" do
-        definition[:monitor_ids] = ["#{project.kennel_id}:b"]
-        id_map.set("monitor", "a:c", 1)
-        id_map.set("monitor", "#{project.kennel_id}:b", 123)
-        resolved = resolve
-        resolved[:monitor_ids].must_equal [123]
-      end
-
-      it "fail hard when id is still missing after dependent monitors were created by syncer" do
-        definition[:monitor_ids] = ["missing:the_id"]
-        id_map.set("monitor", "missing:the_id", Kennel::IdMap::NEW)
-        e = assert_raises Kennel::UnresolvableIdError do
-          resolve(force: true)
-        end
-        e.message.must_include "circular dependency"
-      end
-    end
-
-    describe "alert_graph" do
-      before { definition[:type] = "alert_graph" }
-
-      it "does not change the alert widget without monitor" do
-        refute resolve.key?(:alert_id)
-      end
-
-      it "does not change the alert widget with a string encoded id" do
-        definition[:alert_id] = "123"
-        resolve[:alert_id].must_equal "123"
-      end
-
-      it "resolves the alert widget with full id" do
-        definition[:alert_id] = "#{project.kennel_id}:b"
-        id_map.set("monitor", "a:c", 1)
-        id_map.set("monitor", "#{project.kennel_id}:b", 123)
-        resolved = resolve
-        resolved[:alert_id].must_equal "123"
-      end
-
-      it "does not fail hard when id is missing to not break when adding new monitors" do
-        definition[:alert_id] = "a:b"
-        id_map.set("monitor", "a:b", Kennel::IdMap::NEW)
-        resolve[:alert_id].must_equal "a:b"
-      end
-    end
-
-    describe "slo" do
-      before { definition[:type] = "slo" }
-
-      it "does not modify regular ids" do
-        definition[:slo_id] = "abcdef1234567"
-        resolve[:slo_id].must_equal "abcdef1234567"
-      end
-
-      it "resolves the slo widget with full id" do
-        definition[:slo_id] = "#{project.kennel_id}:b"
-        id_map.set("slo", "a:c", "1")
-        id_map.set("slo", "#{project.kennel_id}:b", "123")
-        resolved = resolve
-        resolved[:slo_id].must_equal "123"
-      end
-
-      it "resolves nested slo widget with full id" do
-        definition[:widgets] = [{ definition: { slo_id: "#{project.kennel_id}:b", type: "slo" } }]
-        id_map.set("slo", "a:c", "1")
-        id_map.set("slo", "#{project.kennel_id}:b", "123")
-        resolved = resolve
-        resolved[:widgets][0][:definition][:slo_id].must_equal "123"
       end
     end
   end
@@ -363,19 +261,6 @@ describe Kennel::Models::Dashboard do
       with_env DATADOG_SUBDOMAIN: "foobar" do
         Kennel::Models::Dashboard.url(111).must_equal "https://foobar.datadoghq.com/dashboard/111"
       end
-    end
-  end
-
-  describe "#validate_update!" do
-    it "allows update of title" do
-      dashboard.build!.validate_update!(nil, [["~", "title", "foo", "bar"]])
-    end
-
-    it "disallows update of layout_type" do
-      e = assert_raises Kennel::DisallowedUpdateError do
-        dashboard.build!.validate_update!(nil, [["~", "layout_type", "foo", "bar"]])
-      end
-      e.message.must_match(/datadog.*allow.*layout_type/i)
     end
   end
 

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -22,7 +22,6 @@ describe Kennel::Models::Monitor do
   end
 
   let(:project) { TestProject.new }
-  let(:id_map) { Kennel::IdMap.new }
   let(:expected_basic_json) do
     {
       name: "Kennel::Models::Monitor\u{1F512}",
@@ -419,66 +418,6 @@ describe Kennel::Models::Monitor do
     end
   end
 
-  describe "#resolve_linked_tracking_ids" do
-    let(:mon) do
-      monitor(query: -> { "%{#{project.kennel_id}:mon}" }).build!
-    end
-
-    it "does nothing for regular monitors" do
-      mon.resolve_linked_tracking_ids!(id_map, force: false)
-      mon.as_json[:query].must_equal "%{#{project.kennel_id}:mon}"
-    end
-
-    describe "composite monitor" do
-      let(:mon) do
-        monitor(type: -> { "composite" }, query: -> { "%{foo:mon_a} || !%{bar:mon_b}" }).build!
-      end
-
-      it "fails when matching monitor is missing" do
-        e = assert_raises Kennel::UnresolvableIdError do
-          mon.resolve_linked_tracking_ids!(id_map, force: false)
-        end
-        e.message.must_include "test_project:m1 Unable to find monitor foo:mon_a"
-      end
-
-      it "does not fail when unable to try to resolve" do
-        id_map.set("monitor", "foo:mon_a", Kennel::IdMap::NEW)
-        id_map.set("monitor", "bar:mon_b", Kennel::IdMap::NEW)
-        mon.resolve_linked_tracking_ids!(id_map, force: false)
-        mon.as_json[:query].must_equal "%{foo:mon_a} || !%{bar:mon_b}", "query not modified"
-      end
-
-      it "resolves correctly with a matching monitor" do
-        id_map.set("monitor", "foo:mon_x", 3)
-        id_map.set("monitor", "foo:mon_a", 1)
-        id_map.set("monitor", "bar:mon_b", 2)
-        mon.resolve_linked_tracking_ids!(id_map, force: false)
-        mon.as_json[:query].must_equal("1 || !2")
-      end
-    end
-
-    describe "slo alert monitor" do
-      let(:mon) do
-        monitor(type: -> { "slo alert" }, query: -> { "error_budget(\"%{foo:slo_a}\").over(\"7d\") > #{critical}" }).build!
-      end
-
-      it "fails when matching monitor is missing" do
-        e = assert_raises Kennel::UnresolvableIdError do
-          mon.resolve_linked_tracking_ids!(id_map, force: false)
-        end
-        e.message.must_include "test_project:m1 Unable to find slo foo:slo_a"
-      end
-
-      it "resolves correctly with a matching monitor" do
-        id_map.set("slo", "foo:slo_x", "3")
-        id_map.set("slo", "foo:slo_a", "1")
-        id_map.set("slo", "foo:slo_b", "2")
-        mon.resolve_linked_tracking_ids!(id_map, force: false)
-        mon.as_json[:query].must_equal("error_budget(\"1\").over(\"7d\") > 123.0")
-      end
-    end
-  end
-
   describe "#diff" do
     # minitest defines diff, do not override it
     def diff_resource(e, a)
@@ -551,23 +490,6 @@ describe Kennel::Models::Monitor do
         expected_basic_json[:options][:escalation_message] = "keep me"
         diff_resource({}, {}).must_equal [["~", "options.escalation_message", "keep me", nil]]
       end
-    end
-  end
-
-  describe "#validate_update!" do
-    it "allows update of name" do
-      monitor.build!.validate_update!(nil, [["~", "name", "foo", "bar"]])
-    end
-
-    it "disallows update of type" do
-      e = assert_raises Kennel::DisallowedUpdateError do
-        monitor.build!.validate_update!(nil, [["~", "type", "foo", "bar"]])
-      end
-      e.message.must_match(/datadog.*allow.*type/i)
-    end
-
-    it "allows update of metric to query which is used by the importer" do
-      monitor.build!.validate_update!(nil, [["~", "type", "metric alert", "query alert"]])
     end
   end
 

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -249,8 +249,8 @@ describe Kennel::Models::Record do
       end
     end
 
-    let(:actual) { {foo: 1, bar:  2} }
-    let(:expected) { {foo: 3, bar:  4} }
+    let(:actual) { { foo: 1, bar: 2 } }
+    let(:expected) { { foo: 3, bar:  4 } }
 
     it "deletes read-only attributes from actual" do
       klass.normalize(expected, actual)

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -21,7 +21,6 @@ describe Kennel::Models::Slo do
   end
 
   let(:project) { TestProject.new }
-  let(:id_map) { Kennel::IdMap.new }
   let(:expected_basic_json) do
     {
       name: "Foo\u{1F512}",
@@ -73,41 +72,6 @@ describe Kennel::Models::Slo do
         slo(groups: -> { ["foo"] }).build!.as_json,
         expected_basic_json
       )
-    end
-  end
-
-  describe "#resolve_linked_tracking_ids!" do
-    it "ignores empty caused by ignore_default" do
-      slo = slo(monitor_ids: -> { nil }).build!
-      slo.resolve_linked_tracking_ids!(id_map, force: false)
-      refute slo.as_json[:monitor_ids]
-    end
-
-    it "does nothing for hardcoded ids" do
-      slo = slo(monitor_ids: -> { [123] }).build!
-      slo.resolve_linked_tracking_ids!(id_map, force: false)
-      slo.as_json[:monitor_ids].must_equal [123]
-    end
-
-    it "resolves relative ids" do
-      slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] }).build!
-      id_map.set("monitor", "#{project.kennel_id}:mon", 123)
-      slo.resolve_linked_tracking_ids!(id_map, force: false)
-      slo.as_json[:monitor_ids].must_equal [123]
-    end
-
-    it "does not resolve missing ids so they can resolve when monitor was created" do
-      slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] }).build!
-      id_map.set("monitor", "#{project.kennel_id}:mon", Kennel::IdMap::NEW)
-      slo.resolve_linked_tracking_ids!(id_map, force: false)
-      slo.as_json[:monitor_ids].must_equal ["test_project:mon"]
-    end
-
-    it "fails with typos" do
-      slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] }).build!
-      assert_raises Kennel::UnresolvableIdError do
-        slo.resolve_linked_tracking_ids!(id_map, force: false)
-      end
     end
   end
 

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -46,7 +46,7 @@ describe Kennel::Models::Slo do
   describe "#as_json" do
     it "creates a basic json" do
       assert_json_equal(
-        slo.as_json,
+        slo.build!.as_json,
         expected_basic_json
       )
     end
@@ -54,7 +54,7 @@ describe Kennel::Models::Slo do
     it "sets query for metrics" do
       expected_basic_json[:query] = "foo"
       assert_json_equal(
-        slo(query: -> { "foo" }).as_json,
+        slo(query: -> { "foo" }).build!.as_json,
         expected_basic_json
       )
     end
@@ -62,7 +62,7 @@ describe Kennel::Models::Slo do
     it "sets id when updating by id" do
       expected_basic_json[:id] = 123
       assert_json_equal(
-        slo(id: -> { 123 }).as_json,
+        slo(id: -> { 123 }).build!.as_json,
         expected_basic_json
       )
     end
@@ -70,7 +70,7 @@ describe Kennel::Models::Slo do
     it "sets groups when given" do
       expected_basic_json[:groups] = ["foo"]
       assert_json_equal(
-        slo(groups: -> { ["foo"] }).as_json,
+        slo(groups: -> { ["foo"] }).build!.as_json,
         expected_basic_json
       )
     end
@@ -78,33 +78,33 @@ describe Kennel::Models::Slo do
 
   describe "#resolve_linked_tracking_ids!" do
     it "ignores empty caused by ignore_default" do
-      slo = slo(monitor_ids: -> { nil })
+      slo = slo(monitor_ids: -> { nil }).build!
       slo.resolve_linked_tracking_ids!(id_map, force: false)
       refute slo.as_json[:monitor_ids]
     end
 
     it "does nothing for hardcoded ids" do
-      slo = slo(monitor_ids: -> { [123] })
+      slo = slo(monitor_ids: -> { [123] }).build!
       slo.resolve_linked_tracking_ids!(id_map, force: false)
       slo.as_json[:monitor_ids].must_equal [123]
     end
 
     it "resolves relative ids" do
-      slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] })
+      slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] }).build!
       id_map.set("monitor", "#{project.kennel_id}:mon", 123)
       slo.resolve_linked_tracking_ids!(id_map, force: false)
       slo.as_json[:monitor_ids].must_equal [123]
     end
 
     it "does not resolve missing ids so they can resolve when monitor was created" do
-      slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] })
+      slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] }).build!
       id_map.set("monitor", "#{project.kennel_id}:mon", Kennel::IdMap::NEW)
       slo.resolve_linked_tracking_ids!(id_map, force: false)
       slo.as_json[:monitor_ids].must_equal ["test_project:mon"]
     end
 
     it "fails with typos" do
-      slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] })
+      slo = slo(monitor_ids: -> { ["#{project.kennel_id}:mon"] }).build!
       assert_raises Kennel::UnresolvableIdError do
         slo.resolve_linked_tracking_ids!(id_map, force: false)
       end
@@ -113,12 +113,12 @@ describe Kennel::Models::Slo do
 
   describe "#validate_json" do
     it "is valid with no thresholds" do
-      slo.as_json
+      slo.build!
     end
 
     it "is valid when warning not set" do
       s = slo(thresholds: [{ critical: 99 }])
-      s.as_json
+      s.build!
     end
 
     it "is invalid if warning < critical" do

--- a/test/kennel/models/synthetic_test_test.rb
+++ b/test/kennel/models/synthetic_test_test.rb
@@ -44,25 +44,19 @@ describe Kennel::Models::SyntheticTest do
 
   describe "#as_json" do
     it "builds" do
-      assert_json_equal synthetic.as_json, expected_json
-    end
-
-    it "caches" do
-      s = synthetic
-      s.expects(:locations)
-      2.times { s.as_json }
+      assert_json_equal synthetic.build!.as_json, expected_json
     end
 
     it "can add id" do
-      synthetic(id: -> { 123 }).as_json[:id].must_equal 123
+      synthetic(id: -> { 123 }).build!.as_json[:id].must_equal 123
     end
 
     it "can add all locations" do
-      synthetic(locations: -> { :all }).as_json[:locations].size.must_be :>, 5
+      synthetic(locations: -> { :all }).build!.as_json[:locations].size.must_be :>, 5
     end
 
     it "can use super" do
-      synthetic(message: -> { super() }).as_json[:message].must_equal "\n\n@slack-foo"
+      synthetic(message: -> { super() }).build!.as_json[:message].must_equal "\n\n@slack-foo"
     end
   end
 

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -33,7 +33,7 @@ describe Kennel::OptionalValidations do
         unbuilt_class: Kennel::Models::Record,
         tracking_id: nil,
         id: nil,
-        unfiltered_validation_errors: [],
+        unfiltered_validation_errors: []
       )
     end
 

--- a/test/kennel/parts_serializer_test.rb
+++ b/test/kennel/parts_serializer_test.rb
@@ -49,7 +49,7 @@ describe Kennel::PartsSerializer do
   describe "#write" do
     it "saves formatted json" do
       parts = make_project("temp_project", ["foo"]).validated_parts
-      Kennel::PartsSerializer.new(filter: filter).write(parts)
+      Kennel::PartsSerializer.new(filter: filter).write(parts.map(&:build!))
       content = File.read("generated/temp_project/foo.json")
       assert content.start_with?("{\n") # pretty generated
       json = JSON.parse(content, symbolize_names: true)
@@ -58,25 +58,25 @@ describe Kennel::PartsSerializer do
 
     it "keeps same" do
       parts = make_project("temp_project", ["foo"]).validated_parts
-      Kennel::PartsSerializer.new(filter: filter).write(parts)
+      Kennel::PartsSerializer.new(filter: filter).write(parts.map(&:build!))
 
       old = Time.now - 10
       FileUtils.touch "generated/temp_project/foo.json", mtime: old
 
-      Kennel::PartsSerializer.new(filter: filter).write(parts)
+      Kennel::PartsSerializer.new(filter: filter).write(parts.map(&:build!))
 
       File.mtime("generated/temp_project/foo.json").must_equal old
     end
 
     it "overrides different" do
       parts = make_project("temp_project", ["foo"]).validated_parts
-      Kennel::PartsSerializer.new(filter: filter).write(parts)
+      Kennel::PartsSerializer.new(filter: filter).write(parts.map(&:build!))
 
       old = Time.now - 10
       File.write "generated/temp_project/foo.json", "x"
       File.utime(old, old, "generated/temp_project/foo.json")
 
-      Kennel::PartsSerializer.new(filter: filter).write(parts)
+      Kennel::PartsSerializer.new(filter: filter).write(parts.map(&:build!))
 
       File.mtime("generated/temp_project/foo.json").wont_equal old
     end
@@ -88,7 +88,7 @@ describe Kennel::PartsSerializer do
       write "generated/stray_file_not_in_a_subfolder.json", "whatever"
 
       parts = make_project("temp_project", ["foo"]).validated_parts
-      Kennel::PartsSerializer.new(filter: filter).write(parts)
+      Kennel::PartsSerializer.new(filter: filter).write(parts.map(&:build!))
 
       Dir["generated/**/*"].sort.must_equal [
         "generated/temp_project",
@@ -113,7 +113,7 @@ describe Kennel::PartsSerializer do
           *make_project("included1", ["foo1"]).validated_parts,
           *make_project("included2", ["foo2"]).validated_parts
         ]
-        Kennel::PartsSerializer.new(filter: filter).write(parts)
+        Kennel::PartsSerializer.new(filter: filter).write(parts.map(&:build!))
 
         Dir["generated/**/*"].sort.must_equal %w[
           generated/excluded
@@ -149,7 +149,7 @@ describe Kennel::PartsSerializer do
           *make_project("included1", ["foo1"]).validated_parts,
           *make_project("included2", ["foo2"]).validated_parts
         ]
-        Kennel::PartsSerializer.new(filter: filter).write(parts)
+        Kennel::PartsSerializer.new(filter: filter).write(parts.map(&:build!))
 
         Dir["generated/**/*"].sort.must_equal %w[
           generated/excluded

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -31,7 +31,7 @@ describe Kennel::Syncer do
       type: -> { "query alert" },
       critical: -> { 1.0 },
       id: -> { extra[:id] }
-    )
+    ).build!
 
     # make the diff simple
     monitor.as_json[:options] = {
@@ -57,7 +57,7 @@ describe Kennel::Syncer do
       type: -> { nil },
       name: -> { nil },
       options: -> { nil }
-    )
+    ).build!
 
     synthetic.as_json.delete_if { |k, _| ![:tags, :message].include?(k) }
     synthetic.as_json.merge!(extra)
@@ -73,7 +73,7 @@ describe Kennel::Syncer do
       layout_type: -> { "ordered" },
       kennel_id: -> { cid },
       id: -> { extra[:id]&.to_s }
-    )
+    ).build!
     dash.as_json.delete_if { |k, _| ![:description, :options, :widgets, :template_variables].include?(k) }
     dash.as_json.merge!(extra)
     dash
@@ -88,7 +88,7 @@ describe Kennel::Syncer do
       kennel_id: -> { cid },
       id: -> { extra[:id]&.to_s },
       thresholds: -> { [] }
-    )
+    ).build!
     # dash.as_json.delete_if { |k, _| ![:description, :options, :widgets, :template_variables].include?(k) }
     dash.as_json.merge!(extra)
     dash

--- a/test/readme_test.rb
+++ b/test/readme_test.rb
@@ -27,7 +27,7 @@ describe "Readme.md" do
 
     code_blocks.each { |block, line| eval(block, nil, readme, line) } # rubocop:disable Security/Eval
 
-    Kennel::Models::Project.recursive_subclasses.each { |p| p.new.parts.each(&:as_json) }
+    Kennel::Models::Project.recursive_subclasses.each { |p| p.new.parts.map(&:build!) }
   end
 
   it "has language selected for all code blocks so 'working' test above is reliable" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -120,8 +120,7 @@ Minitest::Test.class_eval do
   end
 
   def validation_errors_from(part)
-    part.build
-    part.unfiltered_validation_errors.map(&:text)
+    part.build.unfiltered_validation_errors.map(&:text)
   end
 
   def validation_error_from(part)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,7 +48,7 @@ Minitest::Test.class_eval do
   end
 
   def with_preserved_subclass_tracking
-    preserve = Kennel::SubclassTracking::TRACKED_CLASSES.each_with_object({}) do |klass, h|
+    preserve = Kennel::SubclassTracking.class_variable_get(:@@tracked_classes).each_with_object({}) do |klass, h|
       h[klass] = klass.instance_variable_get(:@subclasses).dup
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,6 +43,24 @@ Minitest::Test.class_eval do
     RUBY
   end
 
+  def self.with_preserved_subclass_tracking
+    around { |t| with_preserved_subclass_tracking(&t) }
+  end
+
+  def with_preserved_subclass_tracking
+    preserve = Kennel::SubclassTracking::TRACKED_CLASSES.each_with_object({}) do |klass, h|
+      h[klass] = klass.instance_variable_get(:@subclasses).dup
+    end
+
+    begin
+      yield
+    ensure
+      preserve.each do |m, subclasses|
+        m.instance_variable_set(:@subclasses, subclasses)
+      end
+    end
+  end
+
   def self.reset_instance
     after do
       Kennel.instance_variable_set(:@instance, nil)


### PR DESCRIPTION
This PR touches a lot of files, but there's hardly any new code.

Splits "Record" and its subclasses into "Builder" and "Built" halves.

Motivation for this PR:

The lifetime of a "Record" instance (i.e. a monitor, dashboard, etc) is very roughly:

- instantiate with settings
- call "build", which runs build_json and validate_json
- potentially store in `./generated`, and run in the Syncer for a plan / update

If one analyzes which methods are called pre- and post- "build" (or more specifically, pre- and post- the moment that build finishes), then we see a clear pattern:

- These methods are _only_ called post "build": resolve_linked_tracking_ids!, add_tracking_id, filtered_validation_errors, tracking_id?, resolve, as_json, diff, resolve_link
- A few methods are called both pre- and post-build: project, tracking_id, id
- Everything else is _only_ called pre-build

This suggests that the pre- and post-build objects should actually be in separate classes; and that's what this PR implements. Splitting a big class into two smaller parts with a clear integration between the two, makes both parts easier to work with.

The junction between the two halves is here:
https://github.com/grosser/kennel/blob/zdrve/20221209-built/lib/kennel/models/record.rb#L134-L150 calls https://github.com/grosser/kennel/blob/zdrve/20221209-built/lib/kennel/models/built/record.rb#L7-L21 .

Notable mostly-unrelated change also in this PR: [with_preserved_subclass_tracking](https://github.com/grosser/kennel/blob/zdrve/20221209-built/test/test_helper.rb#L46-L62) , which allows tests to instantiate temporary test subclasses without messing up the `subclasses` output for later tests.

Things I'm not wild about in this PR, and would welcome opinions on even more than the rest of the PR: 
- the name "unbuilt_class"
- the fact that we now have two classes called Record, two called Monitor, and so on. The Built classes could just as well be called "BuiltRecord", "BuiltMonitor" and so on. Maybe that would be better.
