### PR TITLE
pass basic config to syncer to avoid reference

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -88,7 +88,12 @@ module Kennel
     def syncer
       @syncer ||= begin
         preload
-        Syncer.new(api, generated, definitions, kennel: self, project_filter: filter.project_filter, tracking_id_filter: filter.tracking_id_filter)
+        Syncer.new(
+          api, generated, definitions,
+          strict_imports: strict_imports,
+          project_filter: filter.project_filter,
+          tracking_id_filter: filter.tracking_id_filter
+        )
       end
     end
 


### PR DESCRIPTION
Engine building a syncer and then passing itself seemed a bit strange
... refactored to pass a simple attribute until we need more config
and if we need more config then we can have a config object

@zdrve 