### PR TITLE
Get rid of Utils.inline_resource_metadata

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -135,8 +135,7 @@ module Kennel
     def definitions(**kwargs)
       @definitions ||= Progress.progress("Downloading definitions", **kwargs) do
         Utils.parallel(Models::Record.subclasses) do |klass|
-          results = api.list(klass.api_resource, with_downtimes: false) # lookup monitors without adding unnecessary downtime information
-          results.each { |a| Utils.inline_resource_metadata(a, klass) }
+          api.list(klass.api_resource, with_downtimes: false) # lookup monitors without adding unnecessary downtime information
         end.flatten(1)
       end
     end

--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -5,6 +5,14 @@ module Kennel
   class Api
     CACHE_FILE = "tmp/cache/details"
 
+    def self.tag(api_resource, reply)
+      klass = Models::Record.api_resource_map[api_resource]
+      reply.merge(
+        klass: klass,
+        tracking_id: klass.parse_tracking_id(reply)
+      )
+    end
+
     def initialize(app_key = nil, api_key = nil)
       @app_key = app_key || ENV.fetch("DATADOG_APP_KEY")
       @api_key = api_key || ENV.fetch("DATADOG_API_KEY")
@@ -16,7 +24,7 @@ module Kennel
       response = request :get, "/api/v1/#{api_resource}/#{id}", params: params
       response = response.fetch(:data) if api_resource == "slo"
       response[:id] = response.delete(:public_id) if api_resource == "synthetics/tests"
-      tag(api_resource, response)
+      self.class.tag(api_resource, response)
     end
 
     def list(api_resource, params = {})
@@ -32,7 +40,7 @@ module Kennel
         # ignore monitor synthetics create and that inherit the kennel_id, we do not directly manage them
         response.reject! { |m| m[:type] == "synthetics alert" } if api_resource == "monitor"
 
-        response.map { |r| tag(api_resource, r) }
+        response.map { |r| self.class.tag(api_resource, r) }
       end
     end
 
@@ -40,13 +48,13 @@ module Kennel
       response = request :post, "/api/v1/#{api_resource}", body: attributes
       response = response.fetch(:data).first if api_resource == "slo"
       response[:id] = response.delete(:public_id) if api_resource == "synthetics/tests"
-      tag(api_resource, response)
+      self.class.tag(api_resource, response)
     end
 
     def update(api_resource, id, attributes)
       response = request :put, "/api/v1/#{api_resource}/#{id}", body: attributes
       response[:id] = response.delete(:public_id) if api_resource == "synthetics/tests"
-      tag(api_resource, response)
+      self.class.tag(api_resource, response)
     end
 
     # - force=true to not dead-lock on dependent monitors+slos
@@ -143,24 +151,6 @@ module Kennel
         result = yield
         File.write(file, Marshal.dump(result))
         result
-      end
-    end
-
-    def tag(api_resource, reply)
-      ResourceTaggedHash.new(api_resource, reply)
-    end
-
-    class ResourceTaggedHash < Hash
-      def initialize(api_resource, hash)
-        super()
-        @klass = Models::Record.api_resource_map[api_resource]
-        merge!(hash)
-      end
-
-      attr_reader :klass
-
-      def tracking_id
-        klass.parse_tracking_id(self)
       end
     end
   end

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -30,7 +30,7 @@ module Kennel
         changes:
           @create.map { |_id, e, _a| Change.new(:create, e.class.api_resource, e.tracking_id, nil) } +
             @update.map { |id, e, _a| Change.new(:update, e.class.api_resource, e.tracking_id, id) } +
-            @delete.map { |id, _e, a| Change.new(:delete, a.fetch(:klass).api_resource, a.fetch(:tracking_id), id) }
+            @delete.map { |id, _e, a| Change.new(:delete, a.klass.api_resource, a.tracking_id, id) }
       )
     end
 
@@ -58,7 +58,6 @@ module Kennel
         message = "#{e.class.api_resource} #{e.tracking_id}"
         Kennel.out.puts "Creating #{message}"
         reply = @api.create e.class.api_resource, e.as_json
-        Utils.inline_resource_metadata reply, e.class
         id = reply.fetch(:id)
         changes << Change.new(:create, e.class.api_resource, e.tracking_id, id)
         populate_id_map [], [reply] # allow resolving ids we could previously no resolve
@@ -74,11 +73,11 @@ module Kennel
       end
 
       @delete.each do |id, _, a|
-        klass = a.fetch(:klass)
-        message = "#{klass.api_resource} #{a.fetch(:tracking_id)} #{id}"
+        klass = a.klass
+        message = "#{klass.api_resource} #{a.tracking_id} #{id}"
         Kennel.out.puts "Deleting #{message}"
         @api.delete klass.api_resource, id
-        changes << Change.new(:delete, klass.api_resource, a.fetch(:tracking_id), id)
+        changes << Change.new(:delete, klass.api_resource, a.tracking_id, id)
         Kennel.out.puts "#{LINE_UP}Deleted #{message}"
       end
 
@@ -145,13 +144,13 @@ module Kennel
         end.compact
 
         # delete previously managed
-        @delete = unmatched_actual.map { |a| [a.fetch(:id), nil, a] if a.fetch(:tracking_id) }.compact
+        @delete = unmatched_actual.map { |a| [a.fetch(:id), nil, a] if a.tracking_id }.compact
 
         # unmatched expected need to be created
         @create = unmatched_expected.map { |e| [nil, e] }
 
         # order to avoid deadlocks
-        @delete.sort_by! { |_, _, a| DELETE_ORDER.index a.fetch(:klass).api_resource }
+        @delete.sort_by! { |_, _, a| DELETE_ORDER.index a.klass.api_resource }
         @update.sort_by! { |_, e, _| DELETE_ORDER.index e.class.api_resource } # slo needs to come before slo alert
       end
     end
@@ -203,15 +202,15 @@ module Kennel
     end
 
     def matching_expected(a, map)
-      klass = a.fetch(:klass)
-      map["#{klass.api_resource}:#{a.fetch(:id)}"] || map[a.fetch(:tracking_id)]
+      klass = a.klass
+      map["#{klass.api_resource}:#{a.fetch(:id)}"] || map[a.tracking_id]
     end
 
     def print_changes(step, list, color)
       return if list.empty?
       list.each do |_, e, a, diff|
-        klass = (e ? e.class : a.fetch(:klass))
-        Kennel.out.puts Console.color(color, "#{step} #{klass.api_resource} #{e&.tracking_id || a.fetch(:tracking_id)}")
+        klass = (e ? e.class : a.klass)
+        Kennel.out.puts Console.color(color, "#{step} #{klass.api_resource} #{e&.tracking_id || a.tracking_id}")
         diff&.each { |args| Kennel.out.puts @attribute_differ.format(*args) } # only for update
       end
     end
@@ -259,18 +258,18 @@ module Kennel
       project_prefixes = @project_filter&.map { |p| "#{p}:" }
       actual.each do |a|
         # ignore when not managed by kennel
-        next unless tracking_id = a.fetch(:tracking_id)
+        next unless tracking_id = a.tracking_id
 
         # ignore when deleted from the codebase
         # (when running with filters we cannot see the other resources in the codebase)
-        api_resource = a.fetch(:klass).api_resource
+        api_resource = a.klass.api_resource
         next if
           !@id_map.get(api_resource, tracking_id) &&
           (!project_prefixes || tracking_id.start_with?(*project_prefixes)) &&
           (!@tracking_id_filter || @tracking_id_filter.include?(tracking_id))
 
         @id_map.set(api_resource, tracking_id, a.fetch(:id))
-        if a[:klass].api_resource == "synthetics/tests"
+        if a.klass.api_resource == "synthetics/tests"
           @id_map.set(Kennel::Models::Monitor.api_resource, tracking_id, a.fetch(:monitor_id))
         end
       end
@@ -283,13 +282,13 @@ module Kennel
     def filter_actual!(actual)
       if @tracking_id_filter
         actual.select! do |a|
-          tracking_id = a.fetch(:tracking_id)
+          tracking_id = a.tracking_id
           !tracking_id || @tracking_id_filter.include?(tracking_id)
         end
       elsif @project_filter
         project_prefixes = @project_filter.map { |p| "#{p}:" }
         actual.select! do |a|
-          tracking_id = a.fetch(:tracking_id)
+          tracking_id = a.tracking_id
           !tracking_id || tracking_id.start_with?(*project_prefixes)
         end
       end

--- a/lib/kennel/utils.rb
+++ b/lib/kennel/utils.rb
@@ -61,11 +61,6 @@ module Kennel
         else []
         end
       end
-
-      def inline_resource_metadata(resource, klass)
-        resource[:klass] = klass
-        resource[:tracking_id] = klass.parse_tracking_id(resource)
-      end
     end
   end
 end

--- a/test/kennel/api_test.rb
+++ b/test/kennel/api_test.rb
@@ -44,32 +44,26 @@ describe Kennel::Api do
         .with(body: nil, headers: { "Content-Type" => "application/json" })
         .to_return(body: { bar: "foo" }.to_json)
       answer = api.show("monitor", 1234)
-      answer.must_equal bar: "foo"
-      answer.klass.must_equal Kennel::Models::Monitor
-      answer.tracking_id.must_be_nil
+      answer.must_equal(bar: "foo", klass: Kennel::Models::Monitor, tracking_id: nil)
     end
 
     it "fetches slo" do
       stub_datadog_request(:get, "slo/1234").to_return(body: { data: { bar: "foo" } }.to_json)
       answer = api.show("slo", "1234")
-      answer.must_equal bar: "foo"
-      answer.klass.must_equal Kennel::Models::Slo
-      answer.tracking_id.must_be_nil
+      answer.must_equal(bar: "foo", klass: Kennel::Models::Slo, tracking_id: nil)
     end
 
     it "fetches synthetics test" do
       stub_datadog_request(:get, "synthetics/tests/1234").to_return(body: { public_id: "1234" }.to_json)
       answer = api.show("synthetics/tests", "1234")
-      answer.must_equal id: "1234"
-      answer.klass.must_equal Kennel::Models::SyntheticTest
-      answer.tracking_id.must_be_nil
+      answer.must_equal(id: "1234", klass: Kennel::Models::SyntheticTest, tracking_id: nil)
     end
 
     it "can pass params so external users can filter" do
       stub_datadog_request(:get, "monitor/1234", "&foo=bar")
         .with(body: nil, headers: { "Content-Type" => "application/json" })
         .to_return(body: { bar: "foo" }.to_json)
-      api.show("monitor", 1234, foo: "bar").must_equal bar: "foo"
+      api.show("monitor", 1234, foo: "bar").must_equal(bar: "foo", klass: Kennel::Models::Monitor, tracking_id: nil)
     end
 
     it "does not ignore 404" do
@@ -86,16 +80,14 @@ describe Kennel::Api do
         .with(body: nil, headers: { "Content-Type" => "application/json" })
         .to_return(body: [{ bar: "foo" }].to_json)
       answer = api.list("monitor", foo: "bar")
-      answer.must_equal [{ bar: "foo" }]
-      answer.map(&:klass).must_equal [Kennel::Models::Monitor]
+      answer.must_equal [{ bar: "foo", klass: Kennel::Models::Monitor, tracking_id: nil }]
     end
 
     it "fetches dashboards" do
       stub_datadog_request(:get, "dashboard")
         .to_return(body: { dashboards: [{ bar: "foo" }] }.to_json)
       answer = api.list("dashboard")
-      answer.must_equal [{ bar: "foo" }]
-      answer.map(&:klass).must_equal [Kennel::Models::Dashboard]
+      answer.must_equal [{ bar: "foo", klass: Kennel::Models::Dashboard, tracking_id: nil }]
     end
 
     it "shows a descriptive failure when request fails" do
@@ -108,8 +100,7 @@ describe Kennel::Api do
     it "fetches syntetic tests" do
       stub_datadog_request(:get, "synthetics/tests").to_return(body: { tests: [{ public_id: "123" }] }.to_json)
       answer = api.list("synthetics/tests")
-      answer.must_equal [{ id: "123" }]
-      answer.map(&:klass).must_equal [Kennel::Models::SyntheticTest]
+      answer.must_equal [{ id: "123", klass: Kennel::Models::SyntheticTest, tracking_id: nil }]
     end
 
     describe "slo" do
@@ -118,7 +109,7 @@ describe Kennel::Api do
         stub_datadog_request(:get, "slo", "&limit=1000&offset=1000").to_return(body: { data: [{ bar: "foo"  }] }.to_json)
         answer = api.list("slo")
         answer.size.must_equal 1001
-        answer.map(&:klass).must_equal([Kennel::Models::Slo] * 1001)
+        answer.map { |r| r.fetch(:klass) }.must_equal([Kennel::Models::Slo] * 1001)
       end
 
       it "fails when pagination would not work" do
@@ -133,8 +124,7 @@ describe Kennel::Api do
       stub_datadog_request(:post, "monitor")
         .with(body: "{\"foo\":\"bar\"}").to_return(body: { bar: "foo" }.to_json)
       answer = api.create("monitor", foo: "bar")
-      answer.must_equal bar: "foo"
-      answer.klass.must_equal Kennel::Models::Monitor
+      answer.must_equal(bar: "foo", klass: Kennel::Models::Monitor, tracking_id: nil)
     end
 
     it "shows a descriptive failure when request fails" do
@@ -154,12 +144,12 @@ describe Kennel::Api do
 
     it "unwraps slo array reply" do
       stub_datadog_request(:post, "slo").to_return(body: { data: [{ bar: "foo" }] }.to_json)
-      api.create("slo", foo: "bar").must_equal bar: "foo"
+      api.create("slo", foo: "bar").must_equal(bar: "foo", klass: Kennel::Models::Slo, tracking_id: nil)
     end
 
     it "fixes synthetic test public_id" do
       stub_datadog_request(:post, "synthetics/tests").to_return(body: { public_id: "123" }.to_json)
-      api.create("synthetics/tests", foo: "bar").must_equal id: "123"
+      api.create("synthetics/tests", foo: "bar").must_equal(id: "123", klass: Kennel::Models::SyntheticTest, tracking_id: nil)
     end
   end
 
@@ -168,13 +158,12 @@ describe Kennel::Api do
       stub_datadog_request(:put, "monitor/123")
         .with(body: "{\"foo\":\"bar\"}").to_return(body: { bar: "foo" }.to_json)
       answer = api.update("monitor", 123, foo: "bar")
-      answer.must_equal bar: "foo"
-      answer.klass.must_equal Kennel::Models::Monitor
+      answer.must_equal(bar: "foo", klass: Kennel::Models::Monitor, tracking_id: nil)
     end
 
     it "updates a synthetics test" do
       stub_datadog_request(:put, "synthetics/tests/123").to_return(body: { public_id: "123" }.to_json)
-      api.update("synthetics/tests", "123", foo: "bar").must_equal id: "123"
+      api.update("synthetics/tests", "123", foo: "bar").must_equal(id: "123", klass: Kennel::Models::SyntheticTest, tracking_id: nil)
     end
   end
 
@@ -224,7 +213,7 @@ describe Kennel::Api do
       stub_datadog_request(:get, "dashboard/123").to_return(body: { bar: "foo" }.to_json)
       list = [{ id: "123", modified_at: "123" }]
       api.fill_details!("dashboard", list)
-      list.must_equal [{ id: "123", modified_at: "123", bar: "foo" }]
+      list.must_equal [{ id: "123", klass: Kennel::Models::Dashboard, tracking_id: nil, modified_at: "123", bar: "foo" }]
     end
 
     it "caches" do
@@ -249,7 +238,7 @@ describe Kennel::Api do
 
     it "does not retry successful" do
       request = stub_datadog_request(:get, "monitor/1234").to_return(body: { bar: "foo" }.to_json)
-      api.show("monitor", 1234).must_equal bar: "foo"
+      api.show("monitor", 1234).must_equal(bar: "foo", klass: Kennel::Models::Monitor, tracking_id: nil)
       assert_requested request
     end
 
@@ -273,7 +262,7 @@ describe Kennel::Api do
           { status: 200, body: { foo: "bar" }.to_json }
         ]
       )
-      api.show("monitor", 1234).must_equal foo: "bar"
+      api.show("monitor", 1234).must_equal(foo: "bar", klass: Kennel::Models::Monitor, tracking_id: nil)
       assert_requested request, times: 2
       stderr.string.must_equal "Retrying on server error 500 for /api/v1/monitor/1234\n"
     end
@@ -302,7 +291,7 @@ describe Kennel::Api do
 
     it "caches" do
       get = stub_datadog_request(:get, "monitor/1234").to_return(body: "{}")
-      2.times { api.show("monitor", 1234).must_equal({}) }
+      2.times { api.show("monitor", 1234).must_equal(klass: Kennel::Models::Monitor, tracking_id: nil) }
       assert_requested get, times: 1
     end
   end

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -14,7 +14,7 @@ describe Kennel::Syncer do
   end
 
   def tagged(api_resource, hash)
-    Kennel::Api::ResourceTaggedHash.new(api_resource, hash)
+    Kennel::Api.tag(api_resource, hash)
   end
 
   def monitor_api_response(pid, cid, extra = {})

--- a/test/kennel/utils_test.rb
+++ b/test/kennel/utils_test.rb
@@ -136,13 +136,4 @@ describe Kennel::Utils do
       Kennel::Utils.all_keys([{ foo: 1 }, [[[{ bar: 2 }]]]]).must_equal [:foo, :bar]
     end
   end
-
-  describe ".inline_resource_metadata" do
-    it "adds klass and tracking_id" do
-      resource = { message: "-- Managed by kennel a:b" }
-      Kennel::Utils.inline_resource_metadata(resource, Kennel::Models::Monitor)
-      resource[:tracking_id].must_equal "a:b"
-      resource[:klass].must_equal Kennel::Models::Monitor
-    end
-  end
 end

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -109,7 +109,7 @@ describe Kennel do
     it "update" do
       Kennel::Api.any_instance.expects(:list).times(models_count).returns([])
       STDIN.expects(:gets).returns("y\n") # proceed ? ... yes!
-      Kennel::Api.any_instance.expects(:create).returns(Kennel::Api::ResourceTaggedHash.new("monitor", id: 123))
+      Kennel::Api.any_instance.expects(:create).returns(Kennel::Api.tag("monitor", id: 123))
 
       kennel.update
 

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -109,7 +109,7 @@ describe Kennel do
     it "update" do
       Kennel::Api.any_instance.expects(:list).times(models_count).returns([])
       STDIN.expects(:gets).returns("y\n") # proceed ? ... yes!
-      Kennel::Api.any_instance.expects(:create).returns(id: 123)
+      Kennel::Api.any_instance.expects(:create).returns(Kennel::Api::ResourceTaggedHash.new("monitor", id: 123))
 
       kennel.update
 


### PR DESCRIPTION
Have `Api` handle it internally.

i.e. every object coming back from `show`, `list`, `create`, or `update` responds to `#klass` (e.g. `Kennel::Models::Monitor`), and (somewhat redundantly) `#tracking_id`).

Slightly less miscellanous code in `Utils`, slightly more in `Api`. More symmetrical code in `Syncer`.
