### PR TITLE
Ensure API methods still work with unmapped resources

### DIFF
--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -7,10 +7,12 @@ module Kennel
 
     def self.tag(api_resource, reply)
       klass = Models::Record.api_resource_map[api_resource]
-      klass ? reply.merge(
+      return reply unless klass # do not blow up on unknown models
+
+      reply.merge(
         klass: klass,
         tracking_id: klass.parse_tracking_id(reply)
-      ) : reply
+      )
     end
 
     def initialize(app_key = nil, api_key = nil)

--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -7,10 +7,10 @@ module Kennel
 
     def self.tag(api_resource, reply)
       klass = Models::Record.api_resource_map[api_resource]
-      reply.merge(
+      klass ? reply.merge(
         klass: klass,
         tracking_id: klass.parse_tracking_id(reply)
-      )
+      ) : reply
     end
 
     def initialize(app_key = nil, api_key = nil)

--- a/test/kennel/api_test.rb
+++ b/test/kennel/api_test.rb
@@ -112,6 +112,12 @@ describe Kennel::Api do
       answer.must_equal [{ id: "123", klass: Kennel::Models::SyntheticTest, tracking_id: nil }]
     end
 
+    it "fetches unknown types" do
+      stub_datadog_request(:get, "monitor/123/search_events").to_return(body: [{ id: "12345" }].to_json)
+      answer = api.list("monitor/123/search_events")
+      answer.must_equal [{ id: "12345" }]
+    end
+
     describe "slo" do
       it "paginates" do
         stub_datadog_request(:get, "slo", "&limit=1000&offset=0").to_return(body: { data: Array.new(1000) { { bar: "foo" } } }.to_json)


### PR DESCRIPTION
#243 introduced incompatibility with api_resources not in the api_resource_map.

This restores the previous behaviour if the klass is unknown.

cc @grosser @zdrve 