### PR TITLE
Delete first, to avoid the duplicate-monitor problem

### DIFF
--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -54,6 +54,15 @@ module Kennel
     def update
       changes = []
 
+      @delete.each do |id, _, a|
+        klass = a.fetch(:klass)
+        message = "#{klass.api_resource} #{a.fetch(:tracking_id)} #{id}"
+        Kennel.out.puts "Deleting #{message}"
+        @api.delete klass.api_resource, id
+        changes << Change.new(:delete, klass.api_resource, a.fetch(:tracking_id), id)
+        Kennel.out.puts "#{LINE_UP}Deleted #{message}"
+      end
+
       each_resolved @create do |_, e|
         message = "#{e.class.api_resource} #{e.tracking_id}"
         Kennel.out.puts "Creating #{message}"
@@ -70,15 +79,6 @@ module Kennel
         @api.update e.class.api_resource, id, e.as_json
         changes << Change.new(:update, e.class.api_resource, e.tracking_id, id)
         Kennel.out.puts "#{LINE_UP}Updated #{message}"
-      end
-
-      @delete.each do |id, _, a|
-        klass = a.fetch(:klass)
-        message = "#{klass.api_resource} #{a.fetch(:tracking_id)} #{id}"
-        Kennel.out.puts "Deleting #{message}"
-        @api.delete klass.api_resource, id
-        changes << Change.new(:delete, klass.api_resource, a.fetch(:tracking_id), id)
-        Kennel.out.puts "#{LINE_UP}Deleted #{message}"
       end
 
       Plan.new(changes: changes)


### PR DESCRIPTION
```
grosser: I assumed kennel would delete the duplicate if found ... maybe we need to add that :hmmm:

zdrve: We might be doing that – but because we do updates before deletes, the update can fail, because it would clash with the other monitor with the same title+query+message, which we haven’t yet deleted.
```

I was all lined up to make a more complex fix for this, then I realised it's super simple: delete first.

This raises two points though, which we can discuss here / address in later PRs:

**Constraints**. Was there a reason why we _had_ to delete last? None of the tests failed when I moved deletions to be first. In general, as we discover Datadog constraints (in this case relating to constraints _between_ objects), we should document them and write a test case for them. Absent of such documentation / test cases, it looks like we can just delete first.

Take, for example, Dashboard widgets. A dashboard (via its widgets) can refer to an SLO: D -> S. Therefore, it would be perfectly reasonable if Datadog enforced these constraints:

* Disallow creation of a dashboard referring to a non-existent SLO
* Disallow update of a dashboard such that it would refer to a non-existent SLO
* Disallow deletion of an SLO referred to by any dashboard

Does Datadog actually enforce any of those constraints? I don't know. I don't _think_ so. But if one day we discover that they do, then we should document + create test cases.

**Plan vs Update**. I've moved deletions to the top for `#update`, but not for `#plan`. This of course means that they return two separate `Plan`s (if one considers that the `changes` in a `Plan` are ordered).

Does this matter? I don't think so. 

We could of course fix this by having `#plan` also return the deletions first, to match `#update`. But why maintain two things in parallel like that? Longer term I want to merge `#plan` and `#update` into one. From the user's point of view, the difference between the two is essentially "do we actually write to Datadog or not?", and yet we currently run vastly different code paths between `#plan` and `#update`, and indeed the latter depends on the former. By merging the two together we can simply run the same logic twice (if we assume that the user needs to see the plan first): the first time in dry-run mode, and the second time for real.

