### PR TITLE
Break up 'Syncer'

### DIFF
--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -202,7 +202,7 @@ module Kennel
         end
       end
 
-      def validate_update!(_actuals, diffs)
+      def validate_update!(diffs)
         _, path, from, to = diffs.find { |diff| diff[1] == "layout_type" }
         invalid_update!(path, from, to) if path
       end

--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -137,7 +137,7 @@ module Kennel
         end
       end
 
-      def validate_update!(_actuals, diffs)
+      def validate_update!(diffs)
         # ensure type does not change, but not if it's metric->query which is supported and used by importer.rb
         _, path, from, to = diffs.detect { |_, path, _, _| path == "type" }
         if path && !(from == "metric alert" && to == "query alert")

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -167,7 +167,7 @@ module Kennel
       end
 
       # Can raise DisallowedUpdateError
-      def validate_update!(*)
+      def validate_update!(_diffs)
       end
 
       def invalid_update!(field, old_value, new_value)

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -158,7 +158,7 @@ module Kennel
     # Now that we have made the plan, we can perform some more validation.
     def validate_changes
       @update.each do |_, expected, actuals, diffs|
-        expected.validate_update!(actuals, diffs)
+        item.expected.validate_update!(diffs)
       end
     end
 

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -63,17 +63,17 @@ module Kennel
         Kennel.out.puts "#{LINE_UP}Deleted #{message}"
       end
 
-      each_resolved @create do |_, e|
+      @resolver.each_resolved @create do |_, e|
         message = "#{e.class.api_resource} #{e.tracking_id}"
         Kennel.out.puts "Creating #{message}"
         reply = @api.create e.class.api_resource, e.as_json
         id = reply.fetch(:id)
         changes << Change.new(:create, e.class.api_resource, e.tracking_id, id)
-        populate_id_map [], [reply] # allow resolving ids we could previously no resolve
+        @resolver.populate_id_map [], [reply] # allow resolving ids we could previously no resolve
         Kennel.out.puts "#{LINE_UP}Created #{message} #{e.class.url(id)}"
       end
 
-      each_resolved @update do |id, e|
+      @resolver.each_resolved @update do |id, e|
         message = "#{e.class.api_resource} #{e.tracking_id} #{e.class.url(id)}"
         Kennel.out.puts "Updating #{message}"
         @api.update e.class.api_resource, id, e.as_json
@@ -86,49 +86,18 @@ module Kennel
 
     private
 
-    # loop over items until everything is resolved or crash when we get stuck
-    # this solves cases like composite monitors depending on each other or monitor->monitor slo->slo monitor chains
-    def each_resolved(list)
-      list = list.dup
-      loop do
-        return if list.empty?
-        list.reject! do |id, e|
-          if resolved?(e)
-            yield id, e
-            true
-          else
-            false
-          end
-        end ||
-          assert_resolved(list[0][1]) # resolve something or show a circular dependency error
-      end
-    end
-
-    # TODO: optimize by storing an instance variable if already resolved
-    def resolved?(e)
-      assert_resolved e
-      true
-    rescue UnresolvableIdError
-      false
-    end
-
-    # raises UnresolvableIdError when not resolved
-    def assert_resolved(e)
-      resolve_linked_tracking_ids! [e], force: true
-    end
-
     def noop?
       @create.empty? && @update.empty? && @delete.empty?
     end
 
     def calculate_changes
       @warnings = []
-      @id_map = IdMap.new
+      @resolver = Resolver.new(project_filter: @project_filter, tracking_id_filter: @tracking_id_filter)
 
       Progress.progress "Diffing" do
-        populate_id_map @expected, @actual
+        @resolver.populate_id_map @expected, @actual
         filter_actual! @actual
-        resolve_linked_tracking_ids! @expected # resolve dependencies to avoid diff
+        @resolver.resolve_linked_tracking_ids! @expected # resolve as many dependencies as possible to reduce the diff
         @expected.each(&:add_tracking_id) # avoid diff with actual, which has tracking_id
 
         # see which expected match the actual
@@ -212,40 +181,6 @@ module Kennel
       end
     end
 
-    def populate_id_map(expected, actual)
-      # mark everything as new
-      expected.each do |e|
-        @id_map.set(e.class.api_resource, e.tracking_id, IdMap::NEW)
-        if e.class.api_resource == "synthetics/tests"
-          @id_map.set(Kennel::Models::Monitor.api_resource, e.tracking_id, IdMap::NEW)
-        end
-      end
-
-      # override resources that exist with their id
-      project_prefixes = @project_filter&.map { |p| "#{p}:" }
-      actual.each do |a|
-        # ignore when not managed by kennel
-        next unless tracking_id = a.fetch(:tracking_id)
-
-        # ignore when deleted from the codebase
-        # (when running with filters we cannot see the other resources in the codebase)
-        api_resource = a.fetch(:klass).api_resource
-        next if
-          !@id_map.get(api_resource, tracking_id) &&
-          (!project_prefixes || tracking_id.start_with?(*project_prefixes)) &&
-          (!@tracking_id_filter || @tracking_id_filter.include?(tracking_id))
-
-        @id_map.set(api_resource, tracking_id, a.fetch(:id))
-        if a.fetch(:klass).api_resource == "synthetics/tests"
-          @id_map.set(Kennel::Models::Monitor.api_resource, tracking_id, a.fetch(:monitor_id))
-        end
-      end
-    end
-
-    def resolve_linked_tracking_ids!(list, force: false)
-      list.each { |e| e.resolve_linked_tracking_ids!(@id_map, force: force) }
-    end
-
     def filter_actual!(actual)
       if @tracking_id_filter
         actual.select! do |a|
@@ -258,6 +193,84 @@ module Kennel
           tracking_id = a.fetch(:tracking_id)
           !tracking_id || tracking_id.start_with?(*project_prefixes)
         end
+      end
+    end
+
+    class Resolver
+      def initialize(project_filter:, tracking_id_filter:)
+        @id_map = IdMap.new
+        @project_filter = project_filter
+        @tracking_id_filter = tracking_id_filter
+      end
+
+      def populate_id_map(expected, actual)
+        # mark everything as new
+        expected.each do |e|
+          id_map.set(e.class.api_resource, e.tracking_id, IdMap::NEW)
+          if e.class.api_resource == "synthetics/tests"
+            id_map.set(Kennel::Models::Monitor.api_resource, e.tracking_id, IdMap::NEW)
+          end
+        end
+
+        # override resources that exist with their id
+        project_prefixes = project_filter&.map { |p| "#{p}:" }
+
+        actual.each do |a|
+          # ignore when not managed by kennel
+          next unless tracking_id = a.fetch(:tracking_id)
+
+          # ignore when deleted from the codebase
+          # (when running with filters we cannot see the other resources in the codebase)
+          api_resource = a.fetch(:klass).api_resource
+          next if
+            !id_map.get(api_resource, tracking_id) &&
+            (!project_prefixes || tracking_id.start_with?(*project_prefixes)) &&
+            (!tracking_id_filter || tracking_id_filter.include?(tracking_id))
+
+          id_map.set(api_resource, tracking_id, a.fetch(:id))
+          if a.fetch(:klass).api_resource == "synthetics/tests"
+            id_map.set(Kennel::Models::Monitor.api_resource, tracking_id, a.fetch(:monitor_id))
+          end
+        end
+      end
+
+      # loop over items until everything is resolved or crash when we get stuck
+      # this solves cases like composite monitors depending on each other or monitor->monitor slo->slo monitor chains
+      def each_resolved(list)
+        list = list.dup
+        loop do
+          return if list.empty?
+          list.reject! do |id, e|
+            if resolved?(e)
+              yield id, e
+              true
+            else
+              false
+            end
+          end ||
+            assert_resolved(list[0][1]) # resolve something or show a circular dependency error
+        end
+      end
+
+      def resolve_linked_tracking_ids!(list, force: false)
+        list.each { |e| e.resolve_linked_tracking_ids!(id_map, force: force) }
+      end
+
+      private
+
+      attr_reader :id_map, :project_filter, :tracking_id_filter
+
+      # TODO: optimize by storing an instance variable if already resolved
+      def resolved?(e)
+        assert_resolved e
+        true
+      rescue UnresolvableIdError
+        false
+      end
+
+      # raises UnresolvableIdError when not resolved
+      def assert_resolved(e)
+        resolve_linked_tracking_ids! [e], force: true
       end
     end
 

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -201,7 +201,7 @@ module Kennel
         return if list.empty?
         list.each do |item|
           Kennel.out.puts Console.color(color, "#{step} #{item.api_resource} #{item.tracking_id}")
-          if item.respond_to?(:diff)
+          if item.class::TYPE == :update
             item.diff.each { |args| Kennel.out.puts @attribute_differ.format(*args) } # only for update
           end
         end

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -371,12 +371,12 @@ describe Kennel::Models::Dashboard do
 
   describe "#validate_update!" do
     it "allows update of title" do
-      dashboard.validate_update!(nil, [["~", "title", "foo", "bar"]])
+      dashboard.validate_update!([["~", "title", "foo", "bar"]])
     end
 
     it "disallows update of layout_type" do
       e = assert_raises Kennel::DisallowedUpdateError do
-        dashboard.validate_update!(nil, [["~", "layout_type", "foo", "bar"]])
+        dashboard.validate_update!([["~", "layout_type", "foo", "bar"]])
       end
       e.message.must_match(/datadog.*allow.*layout_type/i)
     end

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -562,18 +562,18 @@ describe Kennel::Models::Monitor do
 
   describe "#validate_update!" do
     it "allows update of name" do
-      monitor.validate_update!(nil, [["~", "name", "foo", "bar"]])
+      monitor.validate_update!([["~", "name", "foo", "bar"]])
     end
 
     it "disallows update of type" do
       e = assert_raises Kennel::DisallowedUpdateError do
-        monitor.validate_update!(nil, [["~", "type", "foo", "bar"]])
+        monitor.validate_update!([["~", "type", "foo", "bar"]])
       end
       e.message.must_match(/datadog.*allow.*type/i)
     end
 
     it "allows update of metric to query which is used by the importer" do
-      monitor.validate_update!(nil, [["~", "type", "metric alert", "query alert"]])
+      monitor.validate_update!([["~", "type", "metric alert", "query alert"]])
     end
   end
 


### PR DESCRIPTION
This PR:

- removes the always-unused first argument to `validate_update!`
- rearranges the code in Syncer, while leaving the tests unchanged

The rearrangement mostly takes the form of creating several child modules and classes under `Syncer`, containing the same code that used to be in `Syncer`. These new sub-modules/classes remain in `syncer.rb` for now, not least precisely so we can do this refactoring without having to change any tests.

 - `MatchedExpected`, which deals with matching `expected` against `actual`
 - `Resolver`, which does everything related to `IdMap` and resolving Kennel IDs to Datadog IDs
 - `PlanDisplayer`, which handles `print_plan`

Finally there's a `Types` module, and a series of classes (`PlannedCreate` etc) to replace the old `|id, e, a, diffs|` quad.

All of this means that `Syncer` itself (i.e. without the submodules/classes) is now down to only 180 lines (from 300), and easier to follow; and that the code that's there is more readable and symmetrical.

If we wish then in later PRs we might want to (1) refactor the testing such that Syncer is tested separately from the new mods/classes, and (2) move those mods/classes (and their new tests) to their own files.

Presented as individual commits for your reviewing pleasure. ;-) 
