### PR TITLE
Prefer tracking id match over datadog id

### DIFF
--- a/lib/kennel/syncer/matched_expected.rb
+++ b/lib/kennel/syncer/matched_expected.rb
@@ -36,7 +36,12 @@ module Kennel
 
         def matching_expected(a, map)
           klass = a.fetch(:klass)
-          map["#{klass.api_resource}:#{a.fetch(:id)}"] || map[a.fetch(:tracking_id)]
+
+          if (e = map[a.fetch(:tracking_id)])
+            return e if e.class.api_resource == klass.api_resource
+          end
+
+          map["#{klass.api_resource}:#{a.fetch(:id)}"]
         end
       end
     end

--- a/test/kennel/syncer/matched_expected_test.rb
+++ b/test/kennel/syncer/matched_expected_test.rb
@@ -129,4 +129,30 @@ describe Kennel::Syncer::MatchedExpected do
       result
     end
   end
+
+  describe "resolution order" do
+    it "prefers tracking_id over id" do
+      e0 = make_expected("a:a", monitor, 999)
+      e1 = make_expected("b:b", monitor, 777)
+      a = make_actual("a:a", monitor, 777)
+      expected << e0
+      expected << e1
+      actual << a
+
+      matched.must_equal [[e0, a]]
+      unmatched_expected.must_equal [e1]
+      unmatched_actual.must_be_empty
+    end
+  end
+
+  it "refuses to match on tracking_id if the api_resource is different" do
+    e = make_expected("a:a", monitor, nil)
+    a = make_actual("a:a", dashboard, 999)
+    expected << e
+    actual << a
+
+    matched.must_be_empty
+    unmatched_expected.must_equal [e]
+    unmatched_actual.must_equal [a]
+  end
 end


### PR DESCRIPTION

* bug fix: check the api_resource of an "expected" found via tracking id (e.g. don't match a monitor with a dashboard)
* not necessarily a bug fix: prefer tracking id over datadog id

Regarding the second one: until recently I had always thought that Kennel did in fact work exactly like this. It made it easy for me to reason about what `id:` (i.e. the import feature) was for, and how it behaved. And then I found out that in fact it didn't do that at all. But maybe it should. wdyt?


