### PR TITLE
Filtering

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -92,9 +92,8 @@ module Kennel
         preload
         Syncer.new(
           api, generated, definitions,
-          strict_imports: strict_imports,
-          project_filter: filter.project_filter,
-          tracking_id_filter: filter.tracking_id_filter
+          filter: filter,
+          strict_imports: strict_imports
         )
       end
     end

--- a/lib/kennel/filter.rb
+++ b/lib/kennel/filter.rb
@@ -33,19 +33,10 @@ module Kennel
       (tracking_id = ENV["TRACKING_ID"]) && tracking_id.split(",").sort.uniq
     end
 
-    def filter_resources(resources, by, expected, name, env)
+    def filter_resources(resources, by, expected, _name, _env)
       return resources unless expected
 
-      expected = expected.uniq
-      before = resources.dup
-      resources = resources.select { |p| expected.include?(p.send(by)) }
-      keeping = resources.uniq(&by).size
-      return resources if keeping == expected.size
-
-      raise <<~MSG.rstrip
-        #{env}=#{expected.join(",")} matched #{keeping} #{name}, try any of these:
-        #{before.map(&by).sort.uniq.join("\n")}
-      MSG
+      resources.select { |p| expected.uniq.include?(p.send(by)) }
     end
   end
 end

--- a/lib/kennel/filter.rb
+++ b/lib/kennel/filter.rb
@@ -37,7 +37,7 @@ module Kennel
     def tracking_id_in_scope?(tracking_id)
       return true if project_filter.nil? # Minor optimization
 
-      project_id = tracking_id.split(':')[0]
+      project_id = tracking_id.split(":")[0]
       project_id_in_scope?(project_id) && (tracking_id_filter.nil? || tracking_id_filter.include?(tracking_id))
     end
 
@@ -56,7 +56,7 @@ module Kennel
       (tracking_id = ENV["TRACKING_ID"]) && tracking_id.split(",").sort.uniq
     end
 
-    def filter_resources(resources, by, expected, _name, env, existing)
+    def filter_resources(resources, by, expected, _name, _env, existing)
       return resources unless expected
 
       matched = []
@@ -65,7 +65,7 @@ module Kennel
       expected.uniq.each do |exp|
         m = resources.select { |p| p.public_send(by) == exp }
         if m.empty?
-          if !existing.include?(exp)
+          unless existing.include?(exp)
             useless << exp
           end
         else

--- a/lib/kennel/filter.rb
+++ b/lib/kennel/filter.rb
@@ -4,18 +4,41 @@ module Kennel
   class Filter
     attr_reader :project_filter, :tracking_id_filter
 
+    # for testing
+    def self.from(project_filter, tracking_id_filter)
+      allocate.tap do |f|
+        f.instance_variable_set(:@project_filter, project_filter)
+        f.instance_variable_set(:@tracking_id_filter, tracking_id_filter)
+      end
+    end
+
     def initialize
       # build early so we fail fast on invalid user input
       @tracking_id_filter = build_tracking_id_filter
       @project_filter = build_project_filter
     end
 
+    def filtering?
+      !@project_filter.nil?
+    end
+
     def filter_projects(projects)
-      filter_resources(projects, :kennel_id, project_filter, "projects", "PROJECT")
+      filter_resources(projects, :kennel_id, project_filter, "projects", "PROJECT", PartsSerializer.existing_project_ids)
     end
 
     def filter_parts(parts)
-      filter_resources(parts, :tracking_id, tracking_id_filter, "resources", "TRACKING_ID")
+      filter_resources(parts, :tracking_id, tracking_id_filter, "resources", "TRACKING_ID", PartsSerializer.existing_tracking_ids)
+    end
+
+    def project_id_in_scope?(project_id)
+      (project_filter.nil? || project_filter.include?(project_id))
+    end
+
+    def tracking_id_in_scope?(tracking_id)
+      return true if project_filter.nil? # Minor optimization
+
+      project_id = tracking_id.split(':')[0]
+      project_id_in_scope?(project_id) && (tracking_id_filter.nil? || tracking_id_filter.include?(tracking_id))
     end
 
     private
@@ -33,10 +56,31 @@ module Kennel
       (tracking_id = ENV["TRACKING_ID"]) && tracking_id.split(",").sort.uniq
     end
 
-    def filter_resources(resources, by, expected, _name, _env)
+    def filter_resources(resources, by, expected, _name, env, existing)
       return resources unless expected
 
-      resources.select { |p| expected.uniq.include?(p.send(by)) }
+      matched = []
+      useless = []
+
+      expected.uniq.each do |exp|
+        m = resources.select { |p| p.public_send(by) == exp }
+        if m.empty?
+          if !existing.include?(exp)
+            useless << exp
+          end
+        else
+          matched.concat(m)
+        end
+      end
+
+      if useless.any?
+        Kennel.err.puts "Warning: the following filter terms didn't match anything: #{useless.sort.join(", ")}"
+      end
+
+      # Preserve order
+      # Should be unimportant but the tests care
+      matched_object_ids = matched.map(&:object_id)
+      resources.select { |r| matched_object_ids.include?(r.object_id) }
     end
   end
 end

--- a/lib/kennel/parts_serializer.rb
+++ b/lib/kennel/parts_serializer.rb
@@ -64,6 +64,7 @@ module Kennel
 
     def path_for_tracking_id(tracking_id)
       raise "Invalid tracking id #{tracking_id.inspect}" unless tracking_id.match?(/^[A-Za-z0-9._-]+:[A-Za-z0-9._-]+$/o)
+
       "generated/#{tracking_id.tr("/", ":").sub(":", "/")}.json"
     end
 

--- a/lib/kennel/parts_serializer.rb
+++ b/lib/kennel/parts_serializer.rb
@@ -45,6 +45,7 @@ module Kennel
     end
 
     def path_for_tracking_id(tracking_id)
+      raise "Invalid tracking id #{tracking_id.inspect}" unless tracking_id.match?(/^[A-Za-z0-9._-]+:[A-Za-z0-9._-]+$/o)
       "generated/#{tracking_id.tr("/", ":").sub(":", "/")}.json"
     end
 

--- a/lib/kennel/parts_serializer.rb
+++ b/lib/kennel/parts_serializer.rb
@@ -2,6 +2,24 @@
 
 module Kennel
   class PartsSerializer
+    class << self
+      def existing_project_ids
+        Dir["generated/*"].map { |path| path.sub("generated/", "") }.sort
+      end
+
+      def existing_tracking_ids
+        Dir["generated/*/*"].map { |path| tracking_id_from_path(path) }.compact.sort
+      end
+
+      private
+
+      def tracking_id_from_path(path)
+        if (m = path.match(/^generated\/(.*)\/(.*)\.json$/))
+          "#{m[1]}:#{m[2]}"
+        end
+      end
+    end
+
     def initialize(filter:)
       @filter = filter
     end

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -20,13 +20,11 @@ module Kennel
 
     Change = Struct.new(:type, :api_resource, :tracking_id, :id)
 
-    def initialize(api, expected, actual, strict_imports: true, project_filter: nil, tracking_id_filter: nil)
+    def initialize(api, expected, actual, filter:, strict_imports: true)
       @api = api
+      @filter = filter
       @strict_imports = strict_imports
-      @project_filter = project_filter
-      @tracking_id_filter = tracking_id_filter
-
-      @resolver = Resolver.new(expected: expected, project_filter: @project_filter, tracking_id_filter: @tracking_id_filter)
+      @resolver = Resolver.new(expected: expected, filter: filter)
 
       internal_plan = calculate_changes(expected: expected, actual: actual)
       validate_changes(internal_plan)
@@ -86,7 +84,7 @@ module Kennel
 
     private
 
-    attr_reader :resolver, :internal_plan
+    attr_reader :filter, :resolver, :internal_plan
 
     def calculate_changes(expected:, actual:)
       @warnings = []
@@ -106,7 +104,7 @@ module Kennel
           # Refuse to "adopt" existing items into kennel while running with a filter (i.e. on a branch).
           # Without this, we'd adopt an item, then the next CI run would delete it
           # (instead of "unadopting" it).
-          e.add_tracking_id unless @project_filter && a.fetch(:tracking_id).nil?
+          e.add_tracking_id unless filter.filtering? && a.fetch(:tracking_id).nil?
           id = a.fetch(:id)
           diff = e.diff(a)
           a[:id] = id
@@ -155,17 +153,11 @@ module Kennel
     end
 
     def filter_actual!(actual)
-      if @tracking_id_filter
-        actual.select! do |a|
-          tracking_id = a.fetch(:tracking_id)
-          !tracking_id || @tracking_id_filter.include?(tracking_id)
-        end
-      elsif @project_filter
-        project_prefixes = @project_filter.map { |p| "#{p}:" }
-        actual.select! do |a|
-          tracking_id = a.fetch(:tracking_id)
-          !tracking_id || tracking_id.start_with?(*project_prefixes)
-        end
+      return unless filter.filtering?
+
+      actual.select! do |a|
+        tracking_id = a.fetch(:tracking_id)
+        tracking_id.nil? || filter.tracking_id_in_scope?(tracking_id)
       end
     end
   end

--- a/lib/kennel/syncer/resolver.rb
+++ b/lib/kennel/syncer/resolver.rb
@@ -5,10 +5,9 @@ require_relative "../id_map"
 module Kennel
   class Syncer
     class Resolver
-      def initialize(expected:, project_filter:, tracking_id_filter:)
+      def initialize(expected:, filter:)
         @id_map = IdMap.new
-        @project_filter = project_filter
-        @tracking_id_filter = tracking_id_filter
+        @filter = filter
 
         # mark everything as new
         expected.each do |e|
@@ -21,8 +20,6 @@ module Kennel
 
       def add_actual(actual)
         # override resources that exist with their id
-        project_prefixes = project_filter&.map { |p| "#{p}:" }
-
         actual.each do |a|
           # ignore when not managed by kennel
           next unless tracking_id = a.fetch(:tracking_id)
@@ -30,10 +27,7 @@ module Kennel
           # ignore when deleted from the codebase
           # (when running with filters we cannot see the other resources in the codebase)
           api_resource = a.fetch(:klass).api_resource
-          next if
-            !id_map.get(api_resource, tracking_id) &&
-            (!project_prefixes || tracking_id.start_with?(*project_prefixes)) &&
-            (!tracking_id_filter || tracking_id_filter.include?(tracking_id))
+          next if !id_map.get(api_resource, tracking_id) && filter.tracking_id_in_scope?(tracking_id)
 
           id_map.set(api_resource, tracking_id, a.fetch(:id))
           if a.fetch(:klass).api_resource == "synthetics/tests"
@@ -68,7 +62,7 @@ module Kennel
 
       private
 
-      attr_reader :id_map, :project_filter, :tracking_id_filter
+      attr_reader :id_map, :filter
 
       # TODO: optimize by storing an instance variable if already resolved
       def resolved?(e)

--- a/test/kennel/filter_test.rb
+++ b/test/kennel/filter_test.rb
@@ -4,6 +4,88 @@ require_relative "../test_helper"
 SingleCov.covered!
 
 describe Kennel::Filter do
+  describe ".from" do
+    it "works with nil" do
+      f = Kennel::Filter.from(nil, nil)
+      f.project_filter.must_be_nil
+      f.tracking_id_filter.must_be_nil
+    end
+
+    it "works with arrays" do
+      f = Kennel::Filter.from(["x"], ["y"])
+      f.project_filter.must_equal(["x"])
+      f.tracking_id_filter.must_equal(["y"])
+    end
+  end
+
+  describe "#filtering?" do
+    it "works without project, without tracking_id" do
+      with_env("PROJECT" => nil, "TRACKING_ID" => nil) do
+        refute Kennel::Filter.new.filtering?
+      end
+    end
+
+    it "works with project, without tracking_id" do
+      with_env("PROJECT" => "foo", "TRACKING_ID" => nil) do
+        assert Kennel::Filter.new.filtering?
+      end
+    end
+
+    it "works without project, with tracking_id" do
+      with_env("PROJECT" => nil, "TRACKING_ID" => "foo:bar") do
+        assert Kennel::Filter.new.filtering?
+      end
+    end
+  end
+
+  describe "#project_id_in_scope?" do
+    it "works without project, without tracking_id" do
+      with_env("PROJECT" => nil, "TRACKING_ID" => nil) do
+        assert Kennel::Filter.new.project_id_in_scope?("foo")
+      end
+    end
+
+    it "works with project, without tracking_id" do
+      with_env("PROJECT" => "foo,foo1", "TRACKING_ID" => nil) do
+        assert Kennel::Filter.new.project_id_in_scope?("foo")
+        assert Kennel::Filter.new.project_id_in_scope?("foo1")
+        refute Kennel::Filter.new.project_id_in_scope?("foo2")
+      end
+    end
+
+    it "works without project, with tracking_id" do
+      with_env("PROJECT" => nil, "TRACKING_ID" => "foo:bar,foo1:bar1") do
+        assert Kennel::Filter.new.project_id_in_scope?("foo")
+        assert Kennel::Filter.new.project_id_in_scope?("foo1")
+        refute Kennel::Filter.new.project_id_in_scope?("foo2")
+      end
+    end
+  end
+
+  describe "#tracking_id_in_scope?" do
+    it "works without project, without tracking_id" do
+      with_env("PROJECT" => nil, "TRACKING_ID" => nil) do
+        assert Kennel::Filter.new.tracking_id_in_scope?("foo:bar")
+      end
+    end
+
+    it "works with project, without tracking_id" do
+      with_env("PROJECT" => "foo,foo1", "TRACKING_ID" => nil) do
+        assert Kennel::Filter.new.tracking_id_in_scope?("foo:bar")
+        assert Kennel::Filter.new.tracking_id_in_scope?("foo1:bar")
+        refute Kennel::Filter.new.tracking_id_in_scope?("foo2:bar2")
+      end
+    end
+
+    it "works without project, with tracking_id" do
+      with_env("PROJECT" => nil, "TRACKING_ID" => "foo:bar,foo1:bar1") do
+        assert Kennel::Filter.new.tracking_id_in_scope?("foo:bar")
+        assert Kennel::Filter.new.tracking_id_in_scope?("foo1:bar1")
+        refute Kennel::Filter.new.tracking_id_in_scope?("foo2:bar2")
+      end
+    end
+  end
+
   describe "#initialize" do
     context "without project, without tracking_id" do
       with_env("PROJECT" => nil, "TRACKING_ID" => nil)
@@ -93,7 +175,7 @@ describe Kennel::Filter do
     let(:things) { [foo, bar, another_foo] }
 
     def run_filter(allow)
-      Kennel::Filter.new.send(:filter_resources, things, :some_property, allow, "things", "SOME_PROPERTY_ENV_VAR")
+      Kennel::Filter.new.send(:filter_resources, things, :some_property, allow, "things", "SOME_PROPERTY_ENV_VAR", [])
     end
 
     it "is a no-op if the filter is unset" do
@@ -124,6 +206,68 @@ describe Kennel::Filter do
     it "filters (> 1 spec, > 1 match for some)" do
       things << baz
       run_filter(["foo", "bar"]).must_equal([foo, bar, another_foo])
+    end
+  end
+
+  describe "no-match warnings" do
+    capture_all
+
+    context "with project, without tracking_id" do
+      it "does not warn if all elements match something" do
+        with_env("PROJECT" => "foo,bar", "TRACKING_ID" => nil) do
+          projects = [stub("P1", kennel_id: "foo")]
+          Kennel::PartsSerializer.stubs(:existing_project_ids).returns(["bar"])
+          Kennel::Filter.new.filter_projects(projects)
+          stderr.string.must_equal ""
+        end
+      end
+
+      it "warns about elements which match nothing" do
+        with_env("PROJECT" => "foo,bar,baz,quux", "TRACKING_ID" => nil) do
+          projects = [stub("P1", kennel_id: "foo")]
+          Kennel::PartsSerializer.stubs(:existing_project_ids).returns(["bar"])
+          Kennel::Filter.new.filter_projects(projects)
+          stderr.string.must_equal "Warning: the following filter terms didn't match anything: baz, quux\n"
+        end
+      end
+    end
+
+    context "without project, with tracking_id" do
+      it "does not warn if all elements match something" do
+        with_env("PROJECT" => nil, "TRACKING_ID" => "foo:x,bar:x") do
+          projects = [stub("P1", kennel_id: "foo")]
+          Kennel::PartsSerializer.stubs(:existing_project_ids).returns(["bar"])
+          Kennel::Filter.new.filter_projects(projects)
+          stderr.string.must_equal ""
+        end
+      end
+
+      it "warns about project id elements which match nothing" do
+        with_env("PROJECT" => nil, "TRACKING_ID" => "foo:x,bar:x,baz:x,quux:x") do
+          projects = [stub("P1", kennel_id: "foo")]
+          Kennel::PartsSerializer.stubs(:existing_project_ids).returns(["bar"])
+          Kennel::Filter.new.filter_projects(projects)
+          stderr.string.must_equal "Warning: the following filter terms didn't match anything: baz, quux\n"
+        end
+      end
+
+      it "does not warn about tracking id elements if everything matches something" do
+        with_env("PROJECT" => nil, "TRACKING_ID" => "foo:x,bar:x") do
+          parts = [stub("P1", tracking_id: "foo:x")]
+          Kennel::PartsSerializer.stubs(:existing_tracking_ids).returns(["bar:x"])
+          Kennel::Filter.new.filter_parts(parts)
+          stderr.string.must_equal ""
+        end
+      end
+
+      it "warns about tracking id elements which match nothing" do
+        with_env("PROJECT" => nil, "TRACKING_ID" => "foo:x,bar:x,baz:x,quux:x") do
+          parts = [stub("P1", tracking_id: "foo:x")]
+          Kennel::PartsSerializer.stubs(:existing_tracking_ids).returns(["bar:x"])
+          Kennel::Filter.new.filter_parts(parts)
+          stderr.string.must_equal "Warning: the following filter terms didn't match anything: baz:x, quux:x\n"
+        end
+      end
     end
   end
 end

--- a/test/kennel/filter_test.rb
+++ b/test/kennel/filter_test.rb
@@ -125,17 +125,5 @@ describe Kennel::Filter do
       things << baz
       run_filter(["foo", "bar"]).must_equal([foo, bar, another_foo])
     end
-
-    it "raises if nothing matched (1 spec)" do
-      e = assert_raises(RuntimeError) { run_filter ["baz"] }
-      e.message.must_include("SOME_PROPERTY_ENV_VAR")
-      e.message.must_include("things")
-    end
-
-    it "raises if nothing matched (> 1 spec)" do
-      e = assert_raises(RuntimeError) { run_filter ["foo", "baz"] }
-      e.message.must_include("SOME_PROPERTY_ENV_VAR")
-      e.message.must_include("things")
-    end
   end
 end

--- a/test/kennel/parts_serializer_test.rb
+++ b/test/kennel/parts_serializer_test.rb
@@ -188,4 +188,27 @@ describe Kennel::PartsSerializer do
       end
     end
   end
+
+  it ".existing_project_ids" do
+    write "generated/foo/one.json", "whatever"
+    write "generated/foo/two.json", "whatever"
+    write "generated/bar/two.json", "whatever"
+    Dir.mkdir "generated/empty"
+    Kennel::PartsSerializer.existing_project_ids.must_equal(["foo", "bar", "empty"].sort)
+  end
+
+  it ".existing_tracking_ids" do
+    write "generated/foo/one.json", "whatever"
+    write "generated/foo/two.json", "whatever"
+    write "generated/bar/two.json", "whatever"
+    Dir.mkdir "generated/empty"
+    Kennel::PartsSerializer.existing_tracking_ids.must_equal(["foo:one", "foo:two", "bar:two"].sort)
+  end
+
+  it "ignores unexpected files" do
+    write "generated/foo/one.json", "whatever"
+    write "generated/bar/baz/x", "whatever"
+    write "generated/bar/baz/y.json", "whatever"
+    Kennel::PartsSerializer.existing_tracking_ids.must_equal(["foo:one"].sort)
+  end
 end

--- a/test/kennel/parts_serializer_test.rb
+++ b/test/kennel/parts_serializer_test.rb
@@ -165,5 +165,27 @@ describe Kennel::PartsSerializer do
         ]
       end
     end
+
+    describe "invalid tracking ids" do
+      def refuses(bad_tracking_id)
+        part = Struct.new(:tracking_id).new(bad_tracking_id)
+        e = assert_raises(RuntimeError) do
+          Kennel::PartsSerializer.new(filter: filter).write([part])
+        end
+        e.message.must_include "Invalid tracking id"
+      end
+
+      it "refuses /" do
+        refuses("a/b")
+      end
+
+      it "refuses zero :" do
+        refuses("a-b")
+      end
+
+      it "refuses multiple :" do
+        refuses("a:b:c")
+      end
+    end
   end
 end

--- a/test/kennel/syncer/resolver_test.rb
+++ b/test/kennel/syncer/resolver_test.rb
@@ -3,4 +3,4 @@
 require_relative "../../test_helper"
 
 # Covered by syncer_test.rb
-SingleCov.covered! uncovered: 31
+SingleCov.covered! uncovered: 27

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -116,8 +116,16 @@ describe Kennel::Syncer do
   let(:expected) { [] }
   let(:actual) { dashboards + monitors + slos + synthetics }
   let(:strict_imports) { [true] } # array to allow modification
+
   let(:project_filter) { [] }
   let(:tracking_id_filter) { [] }
+  let(:filter) do
+    Kennel::Filter.from(
+      Kennel::Utils.presence(project_filter),
+      Kennel::Utils.presence(tracking_id_filter)
+    )
+  end
+
   let(:syncer) do
     actual.each do |a|
       klass = a.fetch(:klass)
@@ -126,9 +134,8 @@ describe Kennel::Syncer do
 
     Kennel::Syncer.new(
       api, expected, actual,
-      strict_imports: strict_imports[0],
-      project_filter: Kennel::Utils.presence(project_filter),
-      tracking_id_filter: Kennel::Utils.presence(tracking_id_filter)
+      filter: filter,
+      strict_imports: strict_imports[0]
     )
   end
 


### PR DESCRIPTION
Needs refactoring and maybe also splitting.

* Remove tracking id mangling, by enforcing that tracking ids for example never contain `/` and only ever contain a single `:` => #256
  * this allows us to turn `generated` into a list of tracking IDs; see later for why
* Always pass the filter around as a single object, rather than project_filter + tracking_id_filter => #257 
* Add methods to Filter, for easier use: `#filtering`, `#project_id_in_scope?`, `#tracking_id_in_scope?`
* When considering whether a PROJECT or TRACKING_ID item matches anything or not, also consider `generated`
* Downgrade the error-on-no-matches to a warning; don't show the list of possibles (though TODO, this probably needs reinstating)

Future direction, not in this PR: Filter by regex, e.g. `PROJECT=/help.center/`
