### PR TITLE
Ensure tracking ids don't undergo filesystem mangling

### DIFF
--- a/lib/kennel/parts_serializer.rb
+++ b/lib/kennel/parts_serializer.rb
@@ -45,6 +45,7 @@ module Kennel
     end
 
     def path_for_tracking_id(tracking_id)
+      raise "Invalid tracking id #{tracking_id.inspect}" unless tracking_id.match?(/^[A-Za-z0-9._-]+:[A-Za-z0-9._-]+$/o)
       "generated/#{tracking_id.tr("/", ":").sub(":", "/")}.json"
     end
 

--- a/test/kennel/parts_serializer_test.rb
+++ b/test/kennel/parts_serializer_test.rb
@@ -165,5 +165,27 @@ describe Kennel::PartsSerializer do
         ]
       end
     end
+
+    describe "invalid tracking ids" do
+      def refuses(bad_tracking_id)
+        part = Struct.new(:tracking_id).new(bad_tracking_id)
+        e = assert_raises(RuntimeError) do
+          Kennel::PartsSerializer.new(filter: filter).write([part])
+        end
+        e.message.must_include "Invalid tracking id"
+      end
+
+      it "refuses /" do
+        refuses("a/b")
+      end
+
+      it "refuses zero :" do
+        refuses("a-b")
+      end
+
+      it "refuses multiple :" do
+        refuses("a:b:c")
+      end
+    end
   end
 end


### PR DESCRIPTION
Be more strict about what we allow in tracking ids, thus enforcing the rules which we kind of already take on trust as being true.
