### PR TITLE
on_missing_data: no-data did not work for event alerts, so do not set it

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -23,7 +23,7 @@ module Kennel
         no_data_timeframe: nil, # this works out ok since if notify_no_data is on, it would never be nil
         groupby_simple_monitor: false,
         variables: nil,
-        on_missing_data: "default"
+        on_missing_data: "default" # "default" is "evaluate as zero"
       }.freeze
       DEFAULT_ESCALATION_MESSAGE = ["", nil].freeze
       ALLOWED_PRIORITY_CLASSES = [NilClass, Integer].freeze
@@ -54,7 +54,7 @@ module Kennel
         threshold_windows: -> { nil },
         priority: -> { MONITOR_DEFAULTS.fetch(:priority) },
         variables: -> { MONITOR_OPTION_DEFAULTS.fetch(:variables) },
-        on_missing_data: -> { notify_no_data ? "show_and_notify_no_data" : "default" } # "default" is "evaluate as zero"
+        on_missing_data: -> { MONITOR_OPTION_DEFAULTS.fetch(:on_missing_data) }
       )
 
       def build_json

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -239,16 +239,9 @@ describe Kennel::Models::Monitor do
     end
 
     describe "on_missing_data" do
-      it "defaults when no-data is true" do
+      it "defaults" do
         monitor(
           type: -> { "event-v2 alert" }
-        ).as_json.dig(:options, :on_missing_data).must_equal "show_and_notify_no_data"
-      end
-
-      it "defaults when no-data is fale" do
-        monitor(
-          type: -> { "event-v2 alert" },
-          notify_no_data: -> { false }
         ).as_json.dig(:options, :on_missing_data).must_equal "default"
       end
 


### PR DESCRIPTION
rolling out the previous change resulted in old monitors suddenly going no-data
even if they had no data before
so that means that no-data never worked with the old setting and we should use "default" for everything