### PR TITLE
allow users to paste the generated path of an objects to update it wi…

### DIFF
--- a/lib/kennel/filter.rb
+++ b/lib/kennel/filter.rb
@@ -45,7 +45,13 @@ module Kennel
     end
 
     def build_tracking_id_filter
-      (tracking_id = ENV["TRACKING_ID"]) && tracking_id.split(",").sort.uniq
+      (tracking_id = ENV["TRACKING_ID"]) && tracking_id.split(",").map { |id| tracking_id_path_conversion(id) }.sort.uniq
+    end
+
+    # allow users to paste the generated path of an objects to update it without manually converting
+    def tracking_id_path_conversion(tracking_id)
+      return tracking_id unless tracking_id.end_with?(".json")
+      tracking_id.sub("generated/", "").sub(".json", "").sub("/", ":")
     end
 
     def filter_resources(resources, by, expected, name, env)

--- a/test/kennel/filter_test.rb
+++ b/test/kennel/filter_test.rb
@@ -5,6 +5,13 @@ SingleCov.covered!
 
 describe Kennel::Filter do
   describe "#initialize" do
+    it "can translate file path to tracking id" do
+      f = with_env("TRACKING_ID" => "generated/foo/bar.json") { Kennel::Filter.new }
+      assert f.matches_tracking_id?("foo:bar")
+      refute f.matches_tracking_id?("foo:baz")
+      refute f.matches_tracking_id?("bar:bar")
+    end
+
     context "without project, without tracking_id" do
       with_env("PROJECT" => nil, "TRACKING_ID" => nil)
 


### PR DESCRIPTION
…thout manually converting

sometimes things change I already have the full path and then I'd like to avoid manual conversion
```
rake kennel:update_datadog TRACKING_ID=generated/foo/bar.json
```