### PR TITLE
Allow API cache file to be overridden

### DIFF
--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -3,7 +3,7 @@
 # especially 1-off weirdness that should not leak into other parts of the code
 module Kennel
   class Api
-    CACHE_FILE = "tmp/cache/details"
+    CACHE_FILE = ENV.fetch("KENNEL_API_CACHE_FILE", "tmp/cache/details")
 
     def self.tag(api_resource, reply)
       klass = Models::Record.api_resource_map[api_resource]


### PR DESCRIPTION
Running `rake kennel:dump` (which I do a lot) floods the cache with full details of _every_ dashboard, not just the kennel ones; so the cache becomes very large. There is expiry, so _if_ I don't run `kennel:dump` for a whole month, then the cache gets small again. But if I run the dump at least once a month, then the cache is large, all the time.

The cache size matters, because it takes a non-trivial amount of time to load and persist the cache, which happens on every `rake plan`.

Solution: allow an alternate cache file path to be specified. And then I'll use that override whenever I run `kennel:dump`.

```
-rw-------   1 revans  staff  13587152 14 Feb 10:30 details        <-- kennel:plan
-rw-------   1 revans  staff  78916819 14 Feb 10:27 details.all    <-- kennel:dump
```