### PR TITLE
generate when updating too

### DIFF
--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -111,6 +111,8 @@ namespace :kennel do
 
   desc "update datadog (scope with PROJECT=name)"
   task update_datadog: :environment do
+    Kennel::Tasks.kennel.preload
+    Kennel::Tasks.kennel.generate
     Kennel::Tasks.kennel.update
   end
 

--- a/test/kennel/tasks_test.rb
+++ b/test/kennel/tasks_test.rb
@@ -3,7 +3,7 @@ require_relative "../test_helper"
 require "rake"
 require "kennel/tasks"
 
-SingleCov.covered! uncovered: 45 # TODO: reduce this
+SingleCov.covered! uncovered: 47 # TODO: reduce this
 
 describe "tasks" do
   enable_api


### PR DESCRIPTION
I often mess around in a definition and run update until it does what I want
would be nice to always see the generated diff in git and not have the PR fail on no_diff

happens to make update faster by accident because it was not using preload

@zdrve 