### PR TITLE
Add support for scheduling_options on monitors

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -32,7 +32,7 @@ module Kennel
       settings(
         :query, :name, :message, :escalation_message, :critical, :type, :renotify_interval, :warning, :timeout_h, :evaluation_delay,
         :ok, :no_data_timeframe, :notify_no_data, :notify_audit, :tags, :critical_recovery, :warning_recovery, :require_full_window,
-        :threshold_windows, :new_host_delay, :new_group_delay, :priority, :validate_using_links, :variables, :on_missing_data
+        :threshold_windows, :scheduling_options, :new_host_delay, :new_group_delay, :priority, :validate_using_links, :variables, :on_missing_data
       )
 
       defaults(
@@ -52,6 +52,7 @@ module Kennel
         critical_recovery: -> { nil },
         warning_recovery: -> { nil },
         threshold_windows: -> { nil },
+        scheduling_options: -> { nil },
         priority: -> { MONITOR_DEFAULTS.fetch(:priority) },
         variables: -> { MONITOR_OPTION_DEFAULTS.fetch(:variables) },
         on_missing_data: -> { MONITOR_OPTION_DEFAULTS.fetch(:on_missing_data) }
@@ -112,6 +113,10 @@ module Kennel
 
         if windows = threshold_windows
           options[:threshold_windows] = windows
+        end
+
+        if schedule = scheduling_options
+          options[:scheduling_options] = schedule
         end
 
         # Datadog requires only either new_group_delay or new_host_delay, never both

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -201,6 +201,10 @@ describe Kennel::Models::Monitor do
       monitor(threshold_windows: -> { 20 }).as_json.dig(:options, :threshold_windows).must_equal 20
     end
 
+    it "can set scheduling_options" do
+      monitor(scheduling_options: -> { { evaluation_window: { day_starts: "14:00" } } }).as_json.dig(:options, :scheduling_options).must_equal({ evaluation_window: { day_starts: "14:00" } })
+    end
+
     # happens when project/team have the same tags and they double up
     it "only sets tags once to avoid perma-diff when datadog unqiues them" do
       monitor(tags: -> { ["a", "b", "a"] }).as_json[:tags].must_equal ["a", "b"]


### PR DESCRIPTION
Hi @grosser, I took a quick swing at adding support for `scheduling_options` on monitors. This would help with log quota related monitors resetting on a specific time:

![image](https://user-images.githubusercontent.com/1034297/221024180-08781aa8-d1ab-4d41-8f59-1890a70aa1c3.png)

![image](https://user-images.githubusercontent.com/1034297/221024220-139191d4-2cad-4a87-8f8d-2f16cc07ff13.png)

Implementation isn't exhaustive, but would allow users to pass an object in to set their schedule. Feel free to edit if needed.

Thank you!