### PR TITLE
support dashboard tags

### DIFF
--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -72,6 +72,8 @@ module Kennel
         template_variable_presets: nil
       }.freeze
 
+      TAG_PREFIX = /^team:/
+
       settings(
         :title, :description, :definitions, :widgets, :layout_type, :template_variable_presets, :reflow_type,
         :tags
@@ -83,10 +85,7 @@ module Kennel
         widgets: -> { [] },
         template_variable_presets: -> { DEFAULTS.fetch(:template_variable_presets) },
         reflow_type: -> { layout_type == "ordered" ? "auto" : nil },
-        tags: -> do # not inherited by default to make onboarding to using dashboard tags simple
-          team = project.team
-          team.tag_dashboards ? team.tags : []
-        end
+        tags: -> { project.team.tags } # ideally project.tags but that causes diffs
       )
 
       class << self
@@ -154,7 +153,9 @@ module Kennel
         all_widgets = render_definitions(definitions) + widgets
         expand_q all_widgets
         tags = tags()
-        tags_as_string = (tags.empty? ? "" : " (#{tags.join(" ")})")
+
+        # TODO: remove this once dd UI shows all tags ... maybe remove team tag once that is usable vis UI
+        tags_as_string = (project.team.tag_dashboards && !tags.empty? ? " (#{tags.join(" ")})" : "")
 
         json = super.merge(
           layout_type: layout_type,
@@ -162,7 +163,8 @@ module Kennel
           description: description,
           template_variables: render_template_variables,
           template_variable_presets: template_variable_presets,
-          widgets: all_widgets
+          widgets: all_widgets,
+          tags: tags.grep(TAG_PREFIX)
         )
 
         json[:reflow_type] = reflow_type if reflow_type # setting nil breaks create with "ordered"

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -151,7 +151,7 @@ module Kennel
         rescue StandardError
           if unfiltered_validation_errors.empty?
             @unfiltered_validation_errors = nil
-            raise PrepareError, safe_tracking_id
+            raise PrepareError, safe_tracking_id # FIXME: this makes errors hard to debug when running tests
           end
         end
 

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -23,7 +23,8 @@ describe Kennel::Models::Dashboard do
       template_variables: [],
       template_variable_presets: nil,
       widgets: [],
-      reflow_type: "auto"
+      reflow_type: "auto",
+      tags: ["team:test_team"]
     }
   end
   let(:dashboard_with_requests) do
@@ -59,15 +60,6 @@ describe Kennel::Models::Dashboard do
       dashboard_with_requests.as_json.must_equal expected_json_with_requests
     end
 
-    it "complains when datadog would created a diff by sorting template_variable_presets" do
-      validation_error_from(dashboard(template_variable_presets: -> { [{ name: "B" }, { name: "A" }] }))
-        .must_equal "template_variable_presets must be sorted by name"
-    end
-
-    it "doesn't complain on sorted template_variable_presets" do
-      dashboard(template_variable_presets: -> { [{ name: "A" }, { name: "B" }] }).as_json
-    end
-
     it "adds ID when given" do
       dashboard(id: -> { "abc" }).as_json.must_equal expected_json.merge(id: "abc")
     end
@@ -83,11 +75,6 @@ describe Kennel::Models::Dashboard do
       expected_json[:layout_type] = "free"
       expected_json.delete(:reflow_type)
       dashboard(layout_type: -> { "free" }).as_json.must_equal(expected_json)
-    end
-
-    it "adds team tags when requested" do
-      project.team.class.any_instance.expects(:tag_dashboards).returns(true)
-      dashboard.as_json[:title].must_equal "Hello (team:test_team)🔒"
     end
 
     describe "definitions" do
@@ -137,6 +124,28 @@ describe Kennel::Models::Dashboard do
         assert_raises prepare_error_of(ArgumentError) do
           dashboard(definitions: -> { [["bar", "timeseries", "area", "foo", { a: 1 }]] }).as_json
         end
+      end
+    end
+
+    describe "template_variable_presets" do
+      it "doesn't complain on sorted template_variable_presets" do
+        dashboard(template_variable_presets: -> { [{ name: "A" }, { name: "B" }] }).as_json
+      end
+
+      it "complains when datadog would created a diff by sorting template_variable_presets" do
+        validation_error_from(dashboard(template_variable_presets: -> { [{ name: "B" }, { name: "A" }] }))
+          .must_equal "template_variable_presets must be sorted by name"
+      end
+    end
+
+    describe "tags" do
+      it "adds tags to title when requested" do
+        project.team.class.any_instance.expects(:tag_dashboards).returns(true)
+        dashboard.as_json[:title].must_equal "Hello (team:test_team)🔒"
+      end
+
+      it "does not add non-team tags, mirroring datadogs validation" do
+        dashboard(tags: -> { ["foo"] }).as_json[:tags].must_equal []
       end
     end
   end


### PR DESCRIPTION
dd added them to the API, but not the UI, so we still keep them in the title

FYI tried
```
        # tags can only use team:
        if data[:tags].grep_v(TAG_PREFIX).any?
          invalid! :tags_must_use_team, "tags must use 'team:' prefix"
        end
```
but that failed because we use a bunch of non-team tags ... so keeping all stable until dd decides what to use tags for

## Checklist
- [X] Verified against local install of kennel (using `path:` in Gemfile)
- [X] Added tests
- [x] Updated Readme.md (if user facing behavior changed)
