### PR TITLE
Add `Kennel.in`; test tidying

### DIFF
--- a/lib/kennel.rb
+++ b/lib/kennel.rb
@@ -47,9 +47,10 @@ module Kennel
   GenerationAbortedError = Class.new(StandardError)
 
   class << self
-    attr_accessor :out, :err
+    attr_accessor :in, :out, :err
   end
 
+  self.in = $stdin
   self.out = $stdout
   self.err = $stderr
 

--- a/lib/kennel/console.rb
+++ b/lib/kennel/console.rb
@@ -18,7 +18,7 @@ module Kennel
       def ask?(question)
         Kennel.err.printf color(:red, "#{question} -  press 'y' to continue: ", force: true)
         begin
-          STDIN.gets.chomp == "y"
+          Kennel.in.gets.chomp == "y"
         rescue Interrupt # do not show a backtrace if user decides to Ctrl+C here
           Kennel.err.print "\n"
           exit 1

--- a/lib/kennel/syncer.rb
+++ b/lib/kennel/syncer.rb
@@ -47,7 +47,7 @@ module Kennel
 
     def confirm
       return false if internal_plan.empty?
-      return true if ENV["CI"] || !STDIN.tty? || !Kennel.err.tty?
+      return true if ENV["CI"] || !Kennel.in.tty? || !Kennel.err.tty?
       Console.ask?("Execute Plan ?")
     end
 

--- a/test/kennel/console_test.rb
+++ b/test/kennel/console_test.rb
@@ -56,23 +56,23 @@ describe Kennel::Console do
     capture_all
 
     it "is true on yes" do
-      STDIN.expects(:gets).returns("y\n")
+      Kennel.in.expects(:gets).returns("y\n")
       assert Kennel::Console.ask?("foo")
       stderr.string.must_equal "\e[31mfoo -  press 'y' to continue: \e[0m"
     end
 
     it "is false on no" do
-      STDIN.expects(:gets).returns("n\n")
+      Kennel.in.expects(:gets).returns("n\n")
       refute Kennel::Console.ask?("foo")
     end
 
     it "is false on enter" do
-      STDIN.expects(:gets).returns("\n")
+      Kennel.in.expects(:gets).returns("\n")
       refute Kennel::Console.ask?("foo")
     end
 
     it "does not print a backtrace when user decides to stop with Ctrl+C" do
-      STDIN.expects(:gets).raises(Interrupt)
+      Kennel.in.expects(:gets).raises(Interrupt)
       Kennel::Console.expects(:exit).with(1)
       refute Kennel::Console.ask?("foo")
 

--- a/test/kennel/projects_provider_test.rb
+++ b/test/kennel/projects_provider_test.rb
@@ -12,6 +12,7 @@ describe Kennel::ProjectsProvider do
 
   in_temp_dir
   capture_all
+  without_cached_projects
 
   let(:kennel) { Kennel::Engine.new }
 

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -464,15 +464,15 @@ describe Kennel::Syncer do
 
   describe "#confirm" do
     def expect_gets(answer)
-      STDIN.unstub(:gets)
-      STDIN.stubs(:gets).returns(answer)
+      Kennel.in.unstub(:gets)
+      Kennel.in.stubs(:gets).returns(answer)
     end
 
     before do
       expected << monitor("a", "b")
-      STDIN.stubs(:tty?).returns(true)
+      Kennel.in.stubs(:tty?).returns(true)
       Kennel.err.stubs(:tty?).returns(true)
-      STDIN.expects(:gets).with { raise "unexpected STDIN.gets called" }.never
+      Kennel.in.expects(:gets).with { raise "unexpected Kennel.in.gets called" }.never
     end
 
     it "confirms on y" do
@@ -482,7 +482,7 @@ describe Kennel::Syncer do
     end
 
     it "confirms when automated" do
-      STDIN.stubs(:tty?).returns(false)
+      Kennel.in.stubs(:tty?).returns(false)
       assert syncer.confirm
     end
 

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -17,6 +17,7 @@ describe Kennel do
   let(:kennel) { Kennel::Engine.new }
 
   capture_all
+  without_cached_projects
   in_temp_dir
   enable_api
 

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -102,13 +102,13 @@ describe Kennel do
 
   describe ".update" do
     before do
-      STDIN.expects(:tty?).returns(true)
+      Kennel.in.expects(:tty?).returns(true)
       Kennel.err.stubs(:tty?).returns(true)
     end
 
     it "update" do
       Kennel::Api.any_instance.expects(:list).times(models_count).returns([])
-      STDIN.expects(:gets).returns("y\n") # proceed ? ... yes!
+      Kennel.in.expects(:gets).returns("y\n") # proceed ? ... yes!
       Kennel::Api.any_instance.expects(:create).returns(Kennel::Api.tag("monitor", id: 123))
 
       kennel.update
@@ -119,7 +119,7 @@ describe Kennel do
 
     it "does not update when user does not confirm" do
       Kennel::Api.any_instance.expects(:list).times(models_count).returns([])
-      STDIN.expects(:gets).returns("n\n") # proceed ? ... no!
+      Kennel.in.expects(:gets).returns("n\n") # proceed ? ... no!
       stdout.expects(:tty?).returns(true)
       stderr.expects(:tty?).returns(true)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,9 +43,8 @@ Minitest::Test.class_eval do
     RUBY
   end
 
-  def self.reset_instance
+  def self.without_cached_projects
     after do
-      Kennel.instance_variable_set(:@instance, nil)
       Kennel::ProjectsProvider.remove_class_variable(:@@load_all) if Kennel::ProjectsProvider.class_variable_defined?(:@@load_all)
     end
   end
@@ -77,8 +76,6 @@ Minitest::Test.class_eval do
     ensure
       Kennel.in, Kennel.out, Kennel.err = old
     end
-
-    reset_instance # Nothing to do with capture_all, actually
   end
 
   def self.in_temp_dir(&block)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,12 +66,19 @@ Minitest::Test.class_eval do
     let(:stdout) { StringIO.new }
     let(:stderr) { StringIO.new }
 
-    before do
-      Kennel.out = stdout
-      Kennel.err = stderr
+    around do |t|
+      old = [Kennel.in, Kennel.out, Kennel.err]
+      File.open("/dev/null") do |dev_null|
+        Kennel.in = dev_null
+        Kennel.out = stdout
+        Kennel.err = stderr
+        t.call
+      end
+    ensure
+      Kennel.in, Kennel.out, Kennel.err = old
     end
 
-    reset_instance
+    reset_instance # Nothing to do with capture_all, actually
   end
 
   def self.in_temp_dir(&block)


### PR DESCRIPTION
- Add `Kennel.in`
- In `capture_all`, set up `Kennel.in` to something consistent (so we don't rely on the test execution environment)
- Use `Kennel.in/out/err` consistently (never use `STD...` nor `$std...`)
- Give `reset_instance` a better name
- Remove redundant `Kennel.@instance` reset

## Checklist
- [ ] Verified against local install of kennel (using `path:` in Gemfile)
- [ ] Added tests
- [ ] Updated Readme.md (if user facing behavior changed)
