### PR TITLE
dashboard show_legend defaults to false, so we need to be able to set…

### DIFF
--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -31,7 +31,6 @@ module Kennel
             min: "auto",
             max: "auto"
           },
-          show_legend: true,
           time: {},
           title_align: "left",
           title_size: "16"

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -334,7 +334,7 @@ describe Kennel::Models::Dashboard do
 
     describe "with missing default" do
       let(:json) { expected_json_with_requests }
-      before { json[:widgets][0][:definition][:show_legend] = true }
+      before { json[:widgets][0][:definition][:legend_size] = "0" }
 
       it "ignores timeseries defaults" do
         dashboard_with_requests.diff(json).must_equal []


### PR DESCRIPTION
… true to enable it

## Checklist
- [X] Verified against local install of kennel (using `path:` in Gemfile)
- [X] Added tests
