### PR TITLE
do not throw/catch during error building, just let it fail

### DIFF
--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -2,12 +2,6 @@
 module Kennel
   module Models
     class Record < Base
-      class PrepareError < StandardError
-        def initialize(tracking_id)
-          super("Error while preparing #{tracking_id}")
-        end
-      end
-
       include OptionalValidations
 
       # Apart from if you just don't like the default for some reason,
@@ -140,18 +134,10 @@ module Kennel
 
       def build
         @unfiltered_validation_errors = []
-        json = nil
 
-        begin
-          json = build_json
-          (id = json.delete(:id)) && json[:id] = id
-          validate_json(json)
-        rescue StandardError
-          if unfiltered_validation_errors.empty?
-            @unfiltered_validation_errors = nil
-            raise PrepareError, safe_tracking_id # FIXME: this makes errors hard to debug when running tests
-          end
-        end
+        json = build_json
+        (id = json.delete(:id)) && json[:id] = id
+        validate_json(json)
 
         @filtered_validation_errors = filter_validation_errors
         @as_json = json # Only valid if filtered_validation_errors.empty?

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -55,42 +55,6 @@ describe Kennel::Models::Record do
       record.as_json.must_equal some_json
     end
 
-    it "throws if build_json throws, and there were no validation errors" do
-      record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x")
-      record.define_singleton_method(:build_json) { raise "I crashed :-(" }
-      assert_raises("I crashed :-(") { record.build }
-      record.unfiltered_validation_errors.must_be_nil
-    end
-
-    it "throws if validate_json throws, and there were no validation errors" do
-      record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x")
-      record.define_singleton_method(:validate_json) { |_data| raise "I crashed :-(" }
-      assert_raises("I crashed :-(") { record.build }
-      record.unfiltered_validation_errors.must_be_nil
-    end
-
-    it "does not throw if build_json throws after a validation error" do
-      record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x")
-      record.define_singleton_method(:build_json) do
-        invalid! :wrong, "This is all wrong"
-        raise "I crashed :-("
-      end
-      record.build
-      record.unfiltered_validation_errors.map(&:text).must_equal ["This is all wrong"]
-      record.instance_variable_get(:@as_json).must_be_nil
-    end
-
-    it "does not throw if validate_json throws after a validation error" do
-      record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x")
-      record.define_singleton_method(:validate_json) do |_data|
-        invalid! :wrong, "This is all wrong"
-        raise "I crashed :-("
-      end
-      record.build
-      record.unfiltered_validation_errors.map(&:text).must_equal ["This is all wrong"]
-      record.instance_variable_get(:@as_json).wont_be_nil # for debugging
-    end
-
     it "is capable of collecting multiple errors" do
       record = Kennel::Models::Record.new(TestProject.new, kennel_id: "x")
       record.define_singleton_method(:validate_json) do |_data|


### PR DESCRIPTION
if validation crashes then just let it ... user has to fix it and gets a clean backtrace to do it
instead of us hiding the backtrace and adding more complexity

@zdrve 