### PR TITLE
move all validation related fields/methods to OptionalValidations

### DIFF
--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -77,12 +77,12 @@ module Kennel
         end
       end
 
-      attr_reader :project, :validation_errors, :as_json
+      attr_reader :project, :as_json
 
-      def initialize(project, *args)
+      def initialize(project, ...)
         raise ArgumentError, "First argument must be a project, not #{project.class}" unless project.is_a?(Project)
         @project = project
-        super(*args)
+        super(...)
       end
 
       def diff(actual)
@@ -133,7 +133,6 @@ module Kennel
       end
 
       def build
-        @validation_errors = [] # filled by `invalid!` calls
         @as_json = build_json
         (id = @as_json.delete(:id)) && @as_json[:id] = id
         validate_json(@as_json)
@@ -196,10 +195,6 @@ module Kennel
             or it does exist, but is being deleted.
           MESSAGE
         end
-      end
-
-      def invalid!(tag, message)
-        validation_errors << ValidationMessage.new(tag || OptionalValidations::UNIGNORABLE, message)
       end
 
       def raise_with_location(error, message)

--- a/lib/kennel/optional_validations.rb
+++ b/lib/kennel/optional_validations.rb
@@ -9,6 +9,16 @@ module Kennel
     def self.included(base)
       base.settings :ignored_errors
       base.defaults(ignored_errors: -> { [] })
+      base.attr_reader :validation_errors
+    end
+
+    def initialize(...)
+      super
+      @validation_errors = []
+    end
+
+    def invalid!(tag, message)
+      validation_errors << ValidationMessage.new(tag || OptionalValidations::UNIGNORABLE, message)
     end
 
     def self.valid?(parts)

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -142,7 +142,8 @@ describe Kennel::OptionalValidations do
         it "can ignore failures" do
           ignored_errors << :unused_ignores
           item.build
-          item.filtered_validation_errors.must_equal []
+          errs = Kennel::OptionalValidations.send(:filter_validation_errors, item)
+          errs.must_equal []
         end
       end
     end
@@ -209,7 +210,8 @@ describe Kennel::OptionalValidations do
         it "does not complain if that was ignored" do
           ignored_errors << :unused_ignores
           item.build
-          item.filtered_validation_errors.must_equal []
+          errs = Kennel::OptionalValidations.send(:filter_validation_errors, item)
+          errs.must_equal []
         end
       end
 

--- a/test/kennel/settings_as_methods_test.rb
+++ b/test/kennel/settings_as_methods_test.rb
@@ -59,7 +59,7 @@ describe Kennel::SettingsAsMethods do
     it "stores invocation_location" do
       model = Kennel::Models::Monitor.new(TestProject.new)
       location = model.instance_variable_get(:@invocation_location).sub(/:\d+/, ":123")
-      location.must_equal "lib/kennel/models/record.rb:123:in `initialize'"
+      location.must_equal "lib/kennel/optional_validations.rb:123:in `initialize'"
     end
 
     it "stores invocation_location from first outside project line" do


### PR DESCRIPTION
optional validations needs errors and ignored errors ... but somehow it only took care of half of them
so either they should move all into OptionalValidations (this PR)
or all move into record 🤷 
/cc @zdrve 