### PR TITLE
remove automatic service tagging

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,7 @@ end
 class Bar < Kennel::Models::Project
   defaults(
     team: -> { Teams::Foo.new }, # use mention and tags from the team
+    tags: -> { super() + ["project:bar"] }, # unique tag for all project components
     parts: -> {
       [
         Kennel::Models::Monitor.new(

--- a/lib/kennel/models/project.rb
+++ b/lib/kennel/models/project.rb
@@ -4,7 +4,7 @@ module Kennel
     class Project < Base
       settings :team, :parts, :tags, :mention, :name, :kennel_id
       defaults(
-        tags: -> { ["service:#{kennel_id}"] + team.tags },
+        tags: -> { team.tags },
         mention: -> { team.mention }
       )
 

--- a/template/Readme.md
+++ b/template/Readme.md
@@ -28,6 +28,7 @@ end
 class Bar < Kennel::Models::Project
   defaults(
     team: -> { Teams::Foo.new }, # use mention and tags from the team
+    tags: -> { super() + ["project:bar"] }, # unique tag for all project components
     parts: -> {
       [
         Kennel::Models::Monitor.new(

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -29,7 +29,7 @@ describe Kennel::Models::Monitor do
       type: "query alert",
       query: +"avg(last_5m) > 123.0",
       message: "@slack-foo",
-      tags: ["service:test_project", "team:test_team"],
+      tags: ["team:test_team"],
       priority: nil,
       options: {
         timeout_h: 0,

--- a/test/kennel/models/project_test.rb
+++ b/test/kennel/models/project_test.rb
@@ -53,8 +53,8 @@ describe Kennel::Models::Project do
   end
 
   describe "#tags" do
-    it "adds itself by default" do
-      TestProject.new.tags.must_equal ["service:test_project", "team:test_team"]
+    it "uses team" do
+      TestProject.new.tags.must_equal ["team:test_team"]
     end
   end
 

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -28,7 +28,7 @@ describe Kennel::Models::Slo do
       description: nil,
       thresholds: [],
       monitor_ids: [],
-      tags: ["service:test_project", "team:test_team"],
+      tags: ["team:test_team"],
       type: "metric"
     }
   end

--- a/test/kennel/models/synthetic_test_test.rb
+++ b/test/kennel/models/synthetic_test_test.rb
@@ -30,7 +30,6 @@ describe Kennel::Models::SyntheticTest do
     {
       message: "hey",
       tags: [
-        "service:test_project",
         "team:test_team"
       ],
       config: {},

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -22,7 +22,7 @@ describe Kennel::Syncer do
 
   def monitor_api_response(pid, cid, extra = {})
     tagged("monitor", {
-      tags: extra.delete(:tags) || ["service:a", "team:test_team"],
+      tags: extra.delete(:tags) || ["team:test_team"],
       message: "@slack-foo\n-- Managed by kennel #{pid}:#{cid} in test/test_helper.rb, do not modify manually",
       options: {}
     }.merge(extra))
@@ -378,7 +378,7 @@ describe Kennel::Syncer do
           name: "x\u{1F512}",
           type: "metric",
           thresholds: [],
-          tags: ["team:test_team", "service:a"],
+          tags: ["team:test_team"],
           description: "x\n-- Managed by kennel a:b in test/test_helper.rb, do not modify manually"
         })
       end


### PR DESCRIPTION
leads to too much junk since most people don't realize that it is being added
will then flip our internal hackery to do the opposite
/cc @zdrve 