### PR TITLE
allow setting groupby_simple_monitor

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -26,7 +26,8 @@ module Kennel
         groupby_simple_monitor: false,
         variables: nil,
         on_missing_data: "default", # "default" is "evaluate as zero"
-        notification_preset_name: nil
+        notification_preset_name: nil,
+        notify_by: nil
       }.freeze
       DEFAULT_ESCALATION_MESSAGE = ["", nil].freeze
       ALLOWED_PRIORITY_CLASSES = [NilClass, Integer].freeze
@@ -35,7 +36,7 @@ module Kennel
         :query, :name, :message, :escalation_message, :critical, :type, :renotify_interval, :warning, :timeout_h, :evaluation_delay,
         :ok, :no_data_timeframe, :notify_no_data, :notify_audit, :tags, :critical_recovery, :warning_recovery, :require_full_window,
         :threshold_windows, :scheduling_options, :new_host_delay, :new_group_delay, :priority, :variables, :on_missing_data,
-        :notification_preset_name
+        :notification_preset_name, :notify_by
       )
 
       defaults(
@@ -59,7 +60,8 @@ module Kennel
         priority: -> { MONITOR_DEFAULTS.fetch(:priority) },
         variables: -> { MONITOR_OPTION_DEFAULTS.fetch(:variables) },
         on_missing_data: -> { MONITOR_OPTION_DEFAULTS.fetch(:on_missing_data) },
-        notification_preset_name: -> { MONITOR_OPTION_DEFAULTS.fetch(:notification_preset_name) }
+        notification_preset_name: -> { MONITOR_OPTION_DEFAULTS.fetch(:notification_preset_name) },
+        notify_by: -> { MONITOR_OPTION_DEFAULTS.fetch(:notify_by) }
       )
 
       def build_json
@@ -107,6 +109,11 @@ module Kennel
             # metric and query values are stored as float by datadog
             thresholds.each { |k, v| thresholds[k] = Float(v) }
           end
+        end
+
+        # set without causing lots of nulls to be stored
+        if notify_by_value = notify_by
+          options[:notify_by] = notify_by_value
         end
 
         # setting this via the api breaks the UI with

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -119,6 +119,16 @@ describe Kennel::Models::Monitor do
       end
     end
 
+    describe "notify_by" do
+      it "can set notify_by" do
+        valid_monitor_json(notify_by: -> { ["*"] })[:options][:notify_by].must_equal ["*"]
+      end
+
+      it "does not set when nil to avoid diff" do
+        refute valid_monitor_json[:options].key? :notify_by
+      end
+    end
+
     it "does not set thresholds for composite monitors" do
       json = monitor(
         critical: -> { raise },


### PR DESCRIPTION
new feature in monitor UI
<img width="787" alt="image" src="https://github.com/grosser/kennel/assets/11367/708a8d40-086a-4942-97f0-d262885bfb56">

setting `[]` is not allowed `{"errors":["notify_by must have at least one entry"]}`


- tests
- verified generated/ is not spammed
- verified update + removal works
- verified import works