### PR TITLE
convert api encoding to the local encoding to avoid errors

### DIFF
--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -129,7 +129,7 @@ module Kennel
         if !response.success? && (response.status != 404 || !ignore_404)
           message = +"Error #{response.status} during #{method.upcase} #{path}\n"
           message << "request:\n#{JSON.pretty_generate(body)}\nresponse:\n" if body
-          message << response.body
+          message << response.body.encode(message.encoding, invalid: :replace, undef: :replace)
           raise message
         end
 

--- a/test/kennel/api_test.rb
+++ b/test/kennel/api_test.rb
@@ -157,6 +157,13 @@ describe Kennel::Api do
       TEXT
     end
 
+    it "does not crash when datadog returns ascii encoding" do
+      stub_datadog_request(:post, "monitor")
+        .to_return(body: "hi \255".dup.force_encoding(Encoding::ASCII), status: 300)
+      e = assert_raises(RuntimeError) { api.create("monitor", foo: "bar #{Kennel::Models::Record::LOCK}") }
+      e.message.must_include "hi �"
+    end
+
     it "unwraps slo array reply" do
       stub_datadog_request(:post, "slo").to_return(body: { data: [{ bar: "foo" }] }.to_json)
       api.create("slo", foo: "bar").must_equal(bar: "foo", klass: Kennel::Models::Slo, tracking_id: nil)


### PR DESCRIPTION
see https://github.com/grosser/kennel/issues/294

when we send a request the includes utf8 (like our lock)
and datadog responds with a request that includes utf (like when an slo is invalid it has the slo name which has our lock)
the encodings refuse to be combined and we get
```
*** Encoding::CompatibilityError Exception: incompatible character encodings: UTF-8 and ASCII-8BIT
```
to avoid that we can force the remote into the local encoding
if we ever run into this again it might make sense to always convert the response, but for now just a surgical patch

## Checklist
- [X] Verified against local install of kennel (using `path:` in Gemfile)
- [X] Added tests
