### PR TITLE
Remove renotify interval restriction

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -4,7 +4,6 @@ module Kennel
     class Monitor < Record
       include TagsValidation
 
-      RENOTIFY_INTERVALS = [0, 10, 20, 30, 40, 50, 60, 90, 120, 180, 240, 300, 360, 720, 1440].freeze # minutes
       OPTIONAL_SERVICE_CHECK_THRESHOLDS = [:ok, :warning].freeze
       READONLY_ATTRIBUTES = superclass::READONLY_ATTRIBUTES + [
         :multi, :matching_downtimes, :overall_state_modified, :overall_state, :restricted_roles
@@ -259,11 +258,6 @@ module Kennel
           if Float(query_value) != Float(data.dig(:options, :thresholds, :critical))
             invalid! :critical_does_not_match_query, "critical and value used in query must match"
           end
-        end
-
-        # verify renotify interval is valid
-        unless RENOTIFY_INTERVALS.include? data.dig(:options, :renotify_interval)
-          invalid! :invalid_renotify_interval, "renotify_interval must be one of #{RENOTIFY_INTERVALS.join(", ")}"
         end
 
         if ["query alert", "service check"].include?(type) # TODO: most likely more types need this


### PR DESCRIPTION
Datadog allows arbitrary intervals now so no need to restrict the interval values

<img width="717" alt="image" src="https://github.com/grosser/kennel/assets/14991088/ded2b91c-8a84-4ebc-affb-6102a396f92f">

---------------------------

<img width="730" alt="image" src="https://github.com/grosser/kennel/assets/14991088/449dc61b-753f-4f55-9ac9-15c21e2a3416">

-------------------

<img width="980" alt="image" src="https://github.com/grosser/kennel/assets/14991088/d27f5d50-9a92-469a-9065-729efdeb7f3a">


## Checklist
- [x] Verified against local install of kennel (using `path:` in Gemfile)
- [ ] Added tests
- [ ] Updated Readme.md (if user facing behavior changed)
