### PR TITLE
Send all invalid mentions output to stderr

### DIFF
--- a/lib/kennel/tasks.rb
+++ b/lib/kennel/tasks.rb
@@ -91,8 +91,8 @@ namespace :kennel do
 
     if bad.any?
       url = Kennel::Utils.path_to_url "/account/settings"
-      Kennel.out.puts "Invalid mentions found, either ignore them by adding to `KNOWN` env var or add them via #{url}"
-      bad.each { |f, v| Kennel.out.puts "Invalid mention #{v} in monitor message of #{f}" }
+      Kennel.err.puts "Invalid mentions found, either ignore them by adding to `KNOWN` env var or add them via #{url}"
+      bad.each { |f, v| Kennel.err.puts "Invalid mention #{v} in monitor message of #{f}" }
       Kennel::Tasks.abort ENV["KNOWN_WARNING"]
     end
   end

--- a/test/kennel/tasks_test.rb
+++ b/test/kennel/tasks_test.rb
@@ -303,7 +303,7 @@ describe "tasks" do
     it "fails when unknown mentions are used" do
       content[:message] = "@oo@ps"
       assert_raises { execute }.message.must_equal "Aborted SystemExit"
-      stdout.string.must_include "Invalid mentions"
+      stderr.string.must_include "Invalid mentions"
     end
   end
 


### PR DESCRIPTION
To ensure the "validate mentions" diagnostics come out in an understandable sequence.

It currently ([example](https://github.com/zendesk/kennel/actions/runs/7882274695/job/21507208628?pr=22031#step:5:23)) says:

```text
It generally means that you're trying to add a notification to somewhere for the first time
... (many lines later) ...
Invalid mentions found
```

which makes no sense. So change it to:

```text
Invalid mentions found
...
It generally means that you're trying to add a notification to somewhere for the first time
```
