### PR TITLE
Wrap update details in a collapsible group

### DIFF
--- a/lib/kennel/syncer/plan_printer.rb
+++ b/lib/kennel/syncer/plan_printer.rb
@@ -22,11 +22,19 @@ module Kennel
 
       def print_changes(step, list, color)
         return if list.empty?
+
+        use_groups = ENV.key?("GITHUB_STEP_SUMMARY")
+
         list.each do |item|
+          # No trailing newline
+          Kennel.out.print "::group::" if item.class::TYPE == :update && use_groups
+
           Kennel.out.puts Console.color(color, "#{step} #{item.api_resource} #{item.tracking_id}")
           if item.class::TYPE == :update
             item.diff.each { |args| Kennel.out.puts @attribute_differ.format(*args) } # only for update
           end
+
+          Kennel.out.puts "::endgroup::" if item.class::TYPE == :update && use_groups
         end
       end
     end

--- a/test/kennel/syncer/plan_printer_test.rb
+++ b/test/kennel/syncer/plan_printer_test.rb
@@ -3,4 +3,4 @@
 require_relative "../../test_helper"
 
 # Covered by syncer_test.rb
-SingleCov.covered! uncovered: 12
+SingleCov.covered! uncovered: 15

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -10,6 +10,7 @@ SingleCov.covered! file: "lib/kennel/syncer/types.rb"
 
 describe Kennel::Syncer do
   define_test_classes
+  with_env("GITHUB_STEP_SUMMARY" => nil)
 
   def project(pid)
     project = TestProject.new
@@ -237,6 +238,19 @@ describe Kennel::Syncer do
         Update monitor a:b
           ~tags[1] \"baz\" -> \"bar\"
       TEXT
+    end
+
+    it "wraps in a group, if running under GitHub" do
+      with_env("GITHUB_STEP_SUMMARY" => "true") do
+        expected << monitor("a", "b", tags: ["foo", "bar"])
+        monitors << monitor_api_response("a", "b", tags: ["foo", "baz"])
+        output.must_equal <<~TEXT
+          Plan:
+          ::group::Update monitor a:b
+            ~tags[1] \"baz\" -> \"bar\"
+          ::endgroup::
+        TEXT
+      end
     end
 
     it "deletes when removed from code" do


### PR DESCRIPTION
In the ci-and-update output, the details of every changed field, especially for dashboards, can be very large – and that's especially annoying if it's just noise, because they're not your dashboards.

Wrap the update fields in a `::group::` so that they can be collapsed.

<img width="1302" alt="billede" src="https://github.com/grosser/kennel/assets/48241875/13d21968-6c1b-4f1e-86c3-f99ed14a7504">

https://github.com/zendesk/kennel/actions/runs/8121982186/job/22200952160?pr=22287#step:7:2334


## Checklist
- [ ] Verified against local install of kennel (using `path:` in Gemfile)
- [ ] Added tests
- [ ] Updated Readme.md (if user facing behavior changed)
