### PR TITLE
Remove locked attribute

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -83,7 +83,7 @@ module Kennel
             include_tags: true,
             escalation_message: Utils.presence(escalation_message.strip),
             evaluation_delay: evaluation_delay,
-            locked: false, # setting this to true prevents any edit and breaks updates when using replace workflow
+            locked: false, # deprecated: setting this to true will likely fail
             renotify_interval: renotify_interval || 0,
             variables: variables
           }
@@ -152,6 +152,9 @@ module Kennel
         if (notification_preset_name = notification_preset_name())
           options[:notification_preset_name] = notification_preset_name
         end
+
+        # locked is deprecated, will fail if used
+        options.delete :locked
 
         data
       end
@@ -231,6 +234,9 @@ module Kennel
           options.delete(:escalation_message)
           expected_options.delete(:escalation_message)
         end
+        # locked is deprecated: ignored when diffing
+        options.delete(:locked)
+        expected_options.delete(:locked)
       end
 
       private

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -41,7 +41,6 @@ describe Kennel::Models::Monitor do
         include_tags: true,
         escalation_message: nil,
         evaluation_delay: nil,
-        locked: false,
         renotify_interval: 0,
         thresholds: { critical: 123.0 },
         variables: nil
@@ -579,6 +578,13 @@ describe Kennel::Models::Monitor do
 
     it "ignores type diff between metric and query since datadog uses both randomly" do
       diff_resource({ type: -> { "query alert" } }, {}).must_equal []
+    end
+
+    describe "#locked" do
+      it "ignores deprecated option locked" do
+        expected_basic_json[:options].delete(:locked)
+        diff_resource({}, {}).must_equal []
+      end
     end
 
     describe "#escalation_message" do

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -580,13 +580,6 @@ describe Kennel::Models::Monitor do
       diff_resource({ type: -> { "query alert" } }, {}).must_equal []
     end
 
-    describe "#locked" do
-      it "ignores deprecated option locked" do
-        expected_basic_json[:options].delete(:locked)
-        diff_resource({}, {}).must_equal []
-      end
-    end
-
     describe "#escalation_message" do
       it "ignores missing escalation_message" do
         expected_basic_json[:options].delete(:escalation_message)


### PR DESCRIPTION
According to Datadog docs, [`locked` attribute in monitors is no longer supported.](https://docs.datadoghq.com/monitors/guide/how-to-set-up-rbac-for-monitors/?tab=ui#api)

This PR:
1. Stops sending `locked` as an attribute when creating monitors
1. No longer diffs `locked` attribute when comparing monitors against Datadog

Tested out locally and shows the API request to create monitors without locked attr:
```
{
  "name": "Test Locked attr",
  "tags": ...
  "options": {
    ...
    <no "locked" option>
    }
}
```

Note that when merged, all existing monitor generated JSON will also loose the `locked` attribute, but because the diff is a no-op, Datadog will not be updated (what we want).

## Checklist
- [x] Verified against local install of kennel (using `path:` in Gemfile)
- [ ] Added tests
- [ ] Updated Readme.md (if user facing behavior changed)
