### PR TITLE
support id lookup on slo timeseries dashboard widgets

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -342,7 +342,6 @@ so they can be created in a single update and can be re-created if any of them i
 |Dashboard|uptime|`monitor: {id: "foo:bar"}`|
 |Dashboard|alert_graph|`alert_id: "foo:bar"`|
 |Dashboard|slo|`slo_id: "foo:bar"`|
-|Dashboard|timeseries|`slo_id: "foo:bar"`|
 |Monitor|composite|`query: -> { "%{foo:bar} && %{foo:baz}" }`|
 |Monitor|slo alert|`query: -> { "error_budget(\"%{foo:bar}\").over(\"7d\") > 123.0" }`|
 |Slo|monitor|`monitor_ids: -> ["foo:bar"]`|

--- a/Readme.md
+++ b/Readme.md
@@ -342,7 +342,7 @@ so they can be created in a single update and can be re-created if any of them i
 |Dashboard|uptime|`monitor: {id: "foo:bar"}`|
 |Dashboard|alert_graph|`alert_id: "foo:bar"`|
 |Dashboard|slo|`slo_id: "foo:bar"`|
-|Dashboard|timeseries|`query: -> { data_source: "slo", slo_id: "foo:bar" }`|
+|Dashboard|timeseries|`queries: [{ data_source: "slo", slo_id: "foo:bar" }]`|
 |Monitor|composite|`query: -> { "%{foo:bar} && %{foo:baz}" }`|
 |Monitor|slo alert|`query: -> { "error_budget(\"%{foo:bar}\").over(\"7d\") > 123.0" }`|
 |Slo|monitor|`monitor_ids: -> ["foo:bar"]`|

--- a/Readme.md
+++ b/Readme.md
@@ -342,6 +342,7 @@ so they can be created in a single update and can be re-created if any of them i
 |Dashboard|uptime|`monitor: {id: "foo:bar"}`|
 |Dashboard|alert_graph|`alert_id: "foo:bar"`|
 |Dashboard|slo|`slo_id: "foo:bar"`|
+|Dashboard|timeseries|`query: -> { data_source: "slo", slo_id: "foo:bar" }`|
 |Monitor|composite|`query: -> { "%{foo:bar} && %{foo:baz}" }`|
 |Monitor|slo alert|`query: -> { "error_budget(\"%{foo:bar}\").over(\"7d\") > 123.0" }`|
 |Slo|monitor|`monitor_ids: -> ["foo:bar"]`|

--- a/Readme.md
+++ b/Readme.md
@@ -342,6 +342,7 @@ so they can be created in a single update and can be re-created if any of them i
 |Dashboard|uptime|`monitor: {id: "foo:bar"}`|
 |Dashboard|alert_graph|`alert_id: "foo:bar"`|
 |Dashboard|slo|`slo_id: "foo:bar"`|
+|Dashboard|timeseries|`slo_id: "foo:bar"`|
 |Monitor|composite|`query: -> { "%{foo:bar} && %{foo:baz}" }`|
 |Monitor|slo alert|`query: -> { "error_budget(\"%{foo:bar}\").over(\"7d\") > 123.0" }`|
 |Slo|monitor|`monitor_ids: -> ["foo:bar"]`|

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -198,13 +198,11 @@ module Kennel
           when "timeseries"
             if requests = definition[:requests]
               requests.map do |request|
-                if queries = request[:queries]
-                  queries.map do |query|
-                    if query[:data_source] == 'slo'
-                      if id = query[:slo_id]
-                        query[:slo_id] = resolve(id, :slo, id_map, **args) || id
-                      end
-                    end
+                next unless queries = request[:queries]
+                queries.map do |query|
+                  next unless query[:data_source] == "slo"
+                  if id = query[:slo_id]
+                    query[:slo_id] = resolve(id, :slo, id_map, **args) || id
                   end
                 end
               end

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -195,6 +195,20 @@ module Kennel
             if id = definition[:slo_id]
               definition[:slo_id] = resolve(id, :slo, id_map, **args) || id
             end
+          when "timeseries"
+            if requests = definition[:requests]
+              requests.map do |request|
+                if queries = request[:queries]
+                  queries.map do |query|
+                    if query[:data_source] == 'slo'
+                      if id = query[:slo_id]
+                        query[:slo_id] = resolve(id, :slo, id_map, **args) || id
+                      end
+                    end
+                  end
+                end
+              end
+            end
           end
         end
       end

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -196,14 +196,10 @@ module Kennel
               definition[:slo_id] = resolve(id, :slo, id_map, **args) || id
             end
           when "timeseries"
-            if requests = definition[:requests]
-              requests.map do |request|
-                next unless queries = request[:queries]
-                queries.map do |query|
-                  next unless query[:data_source] == "slo"
-                  if id = query[:slo_id]
-                    query[:slo_id] = resolve(id, :slo, id_map, **args) || id
-                  end
+            definition[:requests]&.each do |request|
+              request[:queries]&.each do |query|
+                if query[:data_source] == "slo" && (slo_id = query[:slo_id])
+                  query[:slo_id] = resolve(slo_id, :slo, id_map, **args) || slo_id
                 end
               end
             end

--- a/template/Readme.md
+++ b/template/Readme.md
@@ -324,6 +324,7 @@ so they can be created in a single update and can be re-created if any of them i
 |Dashboard|uptime|`monitor: {id: "foo:bar"}`|
 |Dashboard|alert_graph|`alert_id: "foo:bar"`|
 |Dashboard|slo|`slo_id: "foo:bar"`|
+|Dashboard|timeseries|`query: -> { data_source: "slo", slo_id: "foo:bar" }`|
 |Monitor|composite|`query: -> { "%{foo:bar} && %{foo:baz}" }`|
 |Monitor|slo alert|`query: -> { "error_budget(\"%{foo:bar}\").over(\"7d\") > 123.0" }`|
 |Slo|monitor|`monitor_ids: -> ["foo:bar"]`|

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -232,6 +232,27 @@ describe Kennel::Models::Dashboard do
         resolved[:widgets][0][:definition][:slo_id].must_equal "123"
       end
     end
+
+    describe "timeseries" do
+      before do
+        definition[:requests] << {
+          queries: [{ data_source: 'slo', slo_id: nil }]
+        }
+      end
+
+      it "does not modify regular ids" do
+        definition[:requests].last[:queries].first[:slo_id] = "abcdef1234567"
+        resolve[:requests].last[:queries].first[:slo_id].must_equal "abcdef1234567"
+      end
+
+      it "resolves the slo widget with full id" do
+        definition[:requests].last[:queries].first[:slo_id] = "#{project.kennel_id}:b"
+        id_map.set("slo", "a:c", "1")
+        id_map.set("slo", "#{project.kennel_id}:b", "123")
+        resolved = resolve
+        resolved[:requests].last[:queries].first[:slo_id].must_equal "123"
+      end
+    end
   end
 
   describe "#diff" do

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -151,6 +151,11 @@ describe Kennel::Models::Dashboard do
       resolve.must_be_nil
     end
 
+    it "ignores unknown widget types" do
+      definition[:type] = "unknown"
+      resolve.keys.must_equal [:requests, :type, :title]
+    end
+
     describe "uptime" do
       before { definition[:type] = "uptime" }
 
@@ -236,21 +241,32 @@ describe Kennel::Models::Dashboard do
     describe "timeseries" do
       before do
         definition[:requests] << {
-          queries: [{ data_source: "slo", slo_id: nil }]
+          queries: [
+            { data_source: "metrics", query: "avg:system.cpu.user{*}" },
+            { data_source: "slo", slo_id: nil }
+          ]
         }
       end
 
+      it "does nothing for regular widgets" do
+        resolve.keys.must_equal [:requests, :type, :title]
+      end
+
       it "does not modify regular ids" do
-        definition[:requests].last[:queries].first[:slo_id] = "abcdef1234567"
-        resolve[:requests].last[:queries].first[:slo_id].must_equal "abcdef1234567"
+        definition[:requests].last[:queries].last[:slo_id] = "abcdef1234567"
+        resolve[:requests].last[:queries].last[:slo_id].must_equal "abcdef1234567"
+      end
+
+      it "ignores missing ids" do
+        assert_nil resolve[:requests].last[:queries].last[:slo_id]
       end
 
       it "resolves the slo widget with full id" do
-        definition[:requests].last[:queries].first[:slo_id] = "#{project.kennel_id}:b"
+        definition[:requests].last[:queries].last[:slo_id] = "#{project.kennel_id}:b"
         id_map.set("slo", "a:c", "1")
         id_map.set("slo", "#{project.kennel_id}:b", "123")
         resolved = resolve
-        resolved[:requests].last[:queries].first[:slo_id].must_equal "123"
+        resolved[:requests].last[:queries].last[:slo_id].must_equal "123"
       end
     end
   end

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -249,7 +249,7 @@ describe Kennel::Models::Dashboard do
       end
 
       it "ignores missing ids" do
-        assert_nil resolve[:requests].last[:queries].last[:slo_id]
+        assert_nil resolve.dig(:requests, 0, :queries, 0, :slo_id)
       end
 
       it "does not modify regular ids" do

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -151,6 +151,8 @@ describe Kennel::Models::Dashboard do
       resolve.must_be_nil
     end
 
+    # Test is necessary for code coverage after adding timeseries support,
+    # to ensure the case statement is tested for unmatched types
     it "ignores unknown widget types" do
       definition[:type] = "unknown"
       resolve.keys.must_equal [:requests, :type, :title]

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -248,13 +248,13 @@ describe Kennel::Models::Dashboard do
         }
       end
 
+      it "ignores missing ids" do
+        assert_nil resolve[:requests].last[:queries].last[:slo_id]
+      end
+
       it "does not modify regular ids" do
         definition[:requests].last[:queries].last[:slo_id] = "abcdef1234567"
         resolve[:requests].last[:queries].last[:slo_id].must_equal "abcdef1234567"
-      end
-
-      it "ignores missing ids" do
-        assert_nil resolve[:requests].last[:queries].last[:slo_id]
       end
 
       it "resolves the slo widget with full id" do

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -248,10 +248,6 @@ describe Kennel::Models::Dashboard do
         }
       end
 
-      it "does nothing for regular widgets" do
-        resolve.keys.must_equal [:requests, :type, :title]
-      end
-
       it "does not modify regular ids" do
         definition[:requests].last[:queries].last[:slo_id] = "abcdef1234567"
         resolve[:requests].last[:queries].last[:slo_id].must_equal "abcdef1234567"

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -236,7 +236,7 @@ describe Kennel::Models::Dashboard do
     describe "timeseries" do
       before do
         definition[:requests] << {
-          queries: [{ data_source: 'slo', slo_id: nil }]
+          queries: [{ data_source: "slo", slo_id: nil }]
         }
       end
 

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -151,8 +151,6 @@ describe Kennel::Models::Dashboard do
       resolve.must_be_nil
     end
 
-    # Test is necessary for code coverage after adding timeseries support,
-    # to ensure the case statement is tested for unmatched types
     it "ignores unknown widget types" do
       definition[:type] = "unknown"
       resolve.keys.must_equal [:requests, :type, :title]


### PR DESCRIPTION
Support fetching SLO ID from Kennel ID in dashboard timeseries widgets.

Example relevant Datadog timeseries widget JSON:

```
            "definition": {
                "title": "Widget Title",
                "title_size": "16",
                "title_align": "left",
                "show_legend": false,
                "type": "timeseries",
                "requests": [
                    {
                        "queries": [
                            {
                                "data_source": "slo",
                                "slo_id": "123456abcdeft1234",
                                "measure": "error_budget_burndown",
                                "group_mode": "components",
                                "slo_query_type": "metric"
                            }
                        ],
                        "response_format": "timeseries",
                        "display_type": "line"
                    }
                ],
```
## Checklist
- [x] Verified against local install of kennel (using `path:` in Gemfile)
- [x] Added tests
- [x] Updated Readme.md (if user facing behavior changed)
