### PR TITLE
Add support for time_slice slo

### DIFF
--- a/lib/kennel/importer.rb
+++ b/lib/kennel/importer.rb
@@ -3,7 +3,7 @@
 module Kennel
   class Importer
     TITLES = [:name, :title].freeze
-    SORT_ORDER = [*TITLES, :id, :kennel_id, :type, :tags, :query, *Models::Record.subclasses.map { |k| k::TRACKING_FIELDS }, :template_variables].freeze
+    SORT_ORDER = [*TITLES, :id, :kennel_id, :type, :tags, :query, :sli_specification, *Models::Record.subclasses.map { |k| k::TRACKING_FIELDS }, :template_variables].freeze
 
     def initialize(api)
       @api = api
@@ -19,9 +19,14 @@ module Kennel
         raise(ArgumentError, "#{resource} is not supported")
 
       data = @api.show(model.api_resource, id)
+      # get sli specification before normalization.
+      sli_specification = data[:sli_specification] || data.dig(:sli_specification, :time_slice)
+
       id = data.fetch(:id) # keep native value
       model.normalize({}, data) # removes id
       data[:id] = id
+
+      data[:sli_specification] = sli_specification if sli_specification
 
       title_field = TITLES.detect { |f| data[f] }
       title = data.fetch(title_field)

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -35,7 +35,7 @@ module Kennel
           type: type
         )
 
-        if v = sliSpecification
+        if type == 'time_slice' && v = sliSpecification
           data[:sliSpecification] = v
         elsif v = query
           data[:query] = v

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -14,7 +14,7 @@ module Kennel
         thresholds: []
       }.freeze
 
-      settings :type, :description, :thresholds, :query, :tags, :monitor_ids, :monitor_tags, :name, :groups, :sliSpecification
+      settings :type, :description, :thresholds, :query, :tags, :monitor_ids, :monitor_tags, :name, :groups, :sli_specification
 
       defaults(
         tags: -> { @project.tags },
@@ -35,8 +35,8 @@ module Kennel
           type: type
         )
 
-        if type == 'time_slice' && v = sliSpecification
-          data[:sliSpecification] = v
+        if type == 'time_slice'
+          data[:sliSpecification] = :sli_specification
         elsif v = query
           data[:query] = v
         end

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -14,7 +14,7 @@ module Kennel
         thresholds: []
       }.freeze
 
-      settings :type, :description, :thresholds, :query, :tags, :monitor_ids, :monitor_tags, :name, :groups
+      settings :type, :description, :thresholds, :query, :tags, :monitor_ids, :monitor_tags, :name, :groups, :sliSpecification
 
       defaults(
         tags: -> { @project.tags },
@@ -35,7 +35,9 @@ module Kennel
           type: type
         )
 
-        if v = query
+        if v = sliSpecification
+          data[:sliSpecification] = v
+        elsif v = query
           data[:query] = v
         end
 

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -11,7 +11,6 @@ describe Kennel::Models::Slo do
 
   def slo(options = {})
     Kennel::Models::Slo.new(
-      # Determine the type from options or default to "metric"
       type = options[:type] || "metric"
       options.delete(:project) || project,
       slo_options ={
@@ -19,7 +18,6 @@ describe Kennel::Models::Slo do
         name: -> { "Foo" },
         kennel_id: -> { "m1" }
       }
-      # Conditionally include sliSpecification if type is "time_slice"
       slo_options[:sliSpecification] = -> { options[:sliSpecification] } if type == "time_slice"
       Kennel::Models::Slo.new(project, slo_options.merge(options))
     )
@@ -85,7 +83,7 @@ describe Kennel::Models::Slo do
 
       expected_basic_json[:sliSpecification] = sli_spec
       assert_json_equal(
-        slo(type: "time_slice", sliSpecification: sli_spec).build_json,
+        slo(type: "time_slice", sli_specification: sli_spec).build_json,
         expected_basic_json
       )
     end


### PR DESCRIPTION
Add suport for `time_slice` [SLO](https://docs.datadoghq.com/service_management/service_level_objectives/time_slice/), that instead `query` use `sliSpecification`: 
```
sli_specification {
    time_slice {
      query {
        formula {
          formula_expression = "query1"
        }
        query {
          metric_query {
            name  = "query1"
            query = "avg:my.custom.count.metric{*}.as_count()"
          }
        }
      }
      comparator = ">"
      threshold  = 0.9
    }
``` 

I'm a beginner at Ruby, so if some of my code isn't well-written, I would appreciate feedback.

## Checklist
- [x] Verified against local install of kennel (using `path:` in Gemfile)
- [x] Added tests
- [ ] Updated Readme.md (if user facing behavior changed)
