### PR TITLE
Enabling declaration of primary SLO

### DIFF
--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -115,6 +115,11 @@ module Kennel
           invalid! :tags_are_upper_case, "Tags must not be upper case (bad tags: #{bad_tags.sort.inspect})"
         end
 
+        # Check that thresholds are not empty
+        if !data[:thresholds] || data[:thresholds].empty?
+          invalid! :thresholds_empty, "SLO must have at least one threshold defined"
+        end
+
         # prevent "Invalid payload: The target is incorrect: target must be a positive number between (0.0, 100.0)"
         data[:thresholds]&.each do |threshold|
           target = threshold.fetch(:target)

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -212,8 +212,8 @@ describe Kennel::Models::Slo do
   end
 
   describe "#validate_json" do
-    it "is valid with no thresholds" do
-      validation_errors_from(slo).must_equal []
+    it "is invalid with empty thresholds" do
+      validation_errors_from(slo).must_equal ["SLO must have at least one threshold defined"]
     end
 
     describe :threshold_target_invalid do
@@ -244,11 +244,11 @@ describe Kennel::Models::Slo do
 
     describe :tags_are_upper_case do
       it "is valid with regular tags" do
-        validation_errors_from(slo(tags: ["foo:bar"])).must_equal []
+        validation_errors_from(slo(tags: ["foo:bar"], thresholds: [{ timeframe: "7d", target: 99 }])).must_equal []
       end
 
       it "is invalid with upcase tags" do
-        validation_errors_from(slo(tags: ["foo:BAR"]))
+        validation_errors_from(slo(tags: ["foo:BAR"], thresholds: [{ timeframe: "7d", target: 99 }]))
           .must_equal ["Tags must not be upper case (bad tags: [\"foo:BAR\"])"]
       end
     end


### PR DESCRIPTION

Datadog still supports SLOs with up to 3 targets via their API. On their UI it is limited to one target per SLO. 

As a result, we have a number of SLOs with multiple targets defined.  Since Kennel does not provide a way to define the primary target, Datadog defaults to 7d. 

To define a primary through the API, one must provide `timeframe`, `warning_threshold` and `target_threshold` outside of the `thresholds` structure.  This works both for POST and PUT methods. 

This aims at providing the ability to define which of the defined threshold is to be considered primary. If primary is unset, the current behavior of Kennel remains: not setting a target, letting Datadog decide of the Primary. 


Note: I am pretty far from being a good rubyist. This PR was made in partnership with an LLM. 


Example: 
`
{
  "name": "mbibaud test",
  "description": "SLO Description",
  "thresholds": [
    {
      "target": 99.5,
      "warning": 99.7,
      "timeframe": "7d"
    },
    {
      "target": 99.5,
      "warning": 99.7,
      "timeframe": "30d"
    },
    {
      "target": 99.5,
      "warning": 99.7,
      "timeframe": "90d"
    }
  ],
  "monitor_ids": [],
  "tags": [
    "service:vector-metrics-egress",
    "team:sre-observability"
  ],
  "type": "metric",
  "timeframe": "30d",
  "warning_threshold": 99.7,
  "target_threshold": 99.5,
  "query": {
    "numerator": "[good events]",
    "denominator": "[total events]"
  },
  "api_resource": "slo"
}
`


## Checklist
- [ ] Verified against local install of kennel (using `path:` in Gemfile)
- [ ] Added tests
- [ ] Updated Readme.md (if user facing behavior changed)
