### PR TITLE
poc unset primary

### DIFF
--- a/lib/kennel/importer.rb
+++ b/lib/kennel/importer.rb
@@ -21,7 +21,14 @@ module Kennel
       data = @api.show(model.api_resource, id)
 
       id = data.fetch(:id) # keep native value
-      model.normalize({}, data) # removes id
+
+      if resource == "slo"
+        # we ignore the 3 copy-pasted fields that track the primary threshold, so we need to sort imported thresholds
+        # or the primary information is lost
+        data[:thresholds].sort! { |t| t[:timeframe] == data[:timeframe] ? 0 : 1 }
+      end
+
+      model.normalize({}, data) # removes id and other fields we do not care about
       data[:id] = id
 
       # title will have the lock symbol we need to remove when re-importing

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -6,7 +6,7 @@ module Kennel
 
       READONLY_ATTRIBUTES = [
         *superclass::READONLY_ATTRIBUTES,
-        :type_id, :monitor_tags, :target_threshold, :timeframe, :warning_threshold
+        :type_id, :monitor_tags
       ].freeze
       TRACKING_FIELD = :description
       DEFAULTS = {
@@ -40,22 +40,11 @@ module Kennel
           type: type
         )
 
-        # Add timeframe and thresholds based on primary setting
-        if primary
-          data[:timeframe] = primary
-
-          threshold =
-            thresholds.detect { |t| t[:timeframe] == primary } ||
-            raise("unable to find threshold with timeframe #{primary}")
-
-          # Only add warning_threshold if it exists
-          if threshold[:warning]
-            data[:warning_threshold] = threshold[:warning]
-          end
-
-          # target is required
-          data[:target_threshold] = threshold[:target]
-        end
+        # add timeframe and thresholds based on "primary" threshold
+        threshold = thresholds.first || raise("not thresholds set")
+        data[:timeframe] = threshold[:timeframe]
+        data[:warning_threshold] = threshold[:warning]
+        data[:target_threshold] = threshold[:target]
 
         if type == "time_slice"
           data[:sli_specification] = sli_specification
@@ -97,6 +86,9 @@ module Kennel
           threshold.delete(:warning_display)
           threshold.delete(:target_display)
         end
+
+        # remove copy-pasted values, if thresholds change these will also change
+        [:timeframe, :warning_threshold, :target_threshold].each { |a| actual[a] = expected[a] }
 
         # tags come in a semi-random order and order is never updated
         expected[:tags]&.sort!


### PR DESCRIPTION
```
Update slo
  ~thresholds[0].timeframe "30d" -> "90d"
  ~thresholds[1].timeframe "7d" -> "30d"
  ~thresholds[2].timeframe "90d" -> "7d"
```

still does not work quiet right, but would get rid of primary