### PR TITLE
prevent dd error from on-missing-data vs timeout_h

### DIFF
--- a/lib/kennel/models/monitor.rb
+++ b/lib/kennel/models/monitor.rb
@@ -161,6 +161,9 @@ module Kennel
         if type == "composite" && action
           invalid! :invalid_no_data_config, "cannot use on_missing_data with composite monitor"
         end
+        if action == "resolve" && timeout_h.to_i != 0
+          invalid! :invalid_no_data_config, "timeout_h cannot be set and non-zero when on_missing_data is `resolve`"
+        end
 
         # on_missing_data cannot be used with notify_no_data + no_data_timeframe
         if action

--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -318,6 +318,15 @@ describe Kennel::Models::Monitor do
           )
         ).must_equal ["set either no_data_timeframe or on_missing_data"]
       end
+
+      it "tells users when timeout_h setting is invalid" do
+        validation_errors_from(
+          monitor(
+            on_missing_data: -> { "resolve" },
+            timeout_h: -> { 1 }
+          )
+        ).must_equal ["timeout_h cannot be set and non-zero when on_missing_data is `resolve`"]
+      end
     end
 
     describe "renotify_interval" do


### PR DESCRIPTION
Thank you for your contribution!

## Checklist
- [ ] Verified against local install of kennel (using `path:` in Gemfile)
- [ ] Added tests
- [ ] Updated Readme.md (if user facing behavior changed)
