### PR TITLE
show invalid on_missing_data config

### DIFF
--- a/test/kennel/models/monitor_test.rb
+++ b/test/kennel/models/monitor_test.rb
@@ -327,6 +327,15 @@ describe Kennel::Models::Monitor do
           )
         ).must_equal ["timeout_h cannot be set and non-zero when on_missing_data is `resolve`"]
       end
+
+      it "tells users when their setting would be ignored because they use default_zero" do
+        validation_errors_from(
+          monitor(
+            on_missing_data: -> { "resolve" },
+            query: -> { "default_zero(foo)" }
+          )
+        ).must_equal ["set on_missing_data to `default` when using default_zero"]
+      end
     end
 
     describe "renotify_interval" do


### PR DESCRIPTION
sometimes this outright breaks the update, sometimes it is just ignored,
but either are bad ... the ignored could cause an infinite update loop if we ever change our internal logic

<img width="411" height="127" alt="image" src="https://github.com/user-attachments/assets/43f44acf-119c-4284-967c-3be669a12b01" />
<img width="607" height="212" alt="image" src="https://github.com/user-attachments/assets/4126ae60-314b-4eaa-9fb3-c2410b9584f1" />
