### PR TITLE
also retry 512 timeout errors on updates

### DIFF
--- a/test/kennel/console_test.rb
+++ b/test/kennel/console_test.rb
@@ -53,7 +53,7 @@ describe Kennel::Console do
   end
 
   describe ".ask?" do
-    capture_all
+    capture_std
 
     it "is true on yes" do
       Kennel.in.expects(:gets).returns("y\n")

--- a/test/kennel/optional_validations_test.rb
+++ b/test/kennel/optional_validations_test.rb
@@ -24,7 +24,7 @@ describe Kennel::OptionalValidations do
   end
 
   describe ".valid?" do
-    capture_all
+    capture_std
 
     def good
       part = mock

--- a/test/kennel/parts_serializer_test.rb
+++ b/test/kennel/parts_serializer_test.rb
@@ -40,7 +40,7 @@ describe Kennel::PartsSerializer do
     with_env(PROJECT: p_arg, TRACKING_ID: t_arg) { Kennel::Filter.new }
   end
 
-  capture_all
+  capture_std
   in_temp_dir
 
   describe "#write" do

--- a/test/kennel/progress_test.rb
+++ b/test/kennel/progress_test.rb
@@ -4,7 +4,7 @@ require_relative "../test_helper"
 SingleCov.covered!
 
 describe Kennel::Progress do
-  capture_all
+  capture_std
 
   describe ".progress" do
     it "shows animated progress with tty" do

--- a/test/kennel/projects_provider_test.rb
+++ b/test/kennel/projects_provider_test.rb
@@ -16,7 +16,7 @@ describe Kennel::ProjectsProvider do
   end
 
   in_temp_dir
-  capture_all
+  capture_std
   without_cached_projects
 
   let(:kennel) { Kennel::Engine.new }

--- a/test/kennel/syncer_test.rb
+++ b/test/kennel/syncer_test.rb
@@ -191,7 +191,7 @@ describe Kennel::Syncer do
     api.stubs(:fill_details!)
   end
 
-  capture_all # TODO: pass an IO to syncer so we don't have to capture all output
+  capture_std # TODO: pass an IO to syncer so we don't have to capture all output
 
   describe "planning" do # plan + print_plan
     let(:plan) do

--- a/test/kennel/tasks_test.rb
+++ b/test/kennel/tasks_test.rb
@@ -17,7 +17,7 @@ describe "tasks" do
   end
 
   enable_api
-  capture_all
+  capture_std
 
   let(:dump_output) do
     <<~TXT

--- a/test/kennel/unmuted_alerts_test.rb
+++ b/test/kennel/unmuted_alerts_test.rb
@@ -5,7 +5,7 @@ require "stringio"
 SingleCov.covered!
 
 describe Kennel::UnmutedAlerts do
-  capture_all
+  capture_std
 
   let(:tag) { "team:compute" }
   let(:monitors) { [monitor] }

--- a/test/kennel_test.rb
+++ b/test/kennel_test.rb
@@ -16,7 +16,7 @@ describe Kennel do
   let(:models_count) { 4 }
   let(:kennel) { Kennel::Engine.new }
 
-  capture_all
+  capture_std
   without_cached_projects
   in_temp_dir
   enable_api

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,7 +63,7 @@ Minitest::Test.class_eval do
     around { |t| with_env(hash, &t) }
   end
 
-  def self.capture_all
+  def self.capture_std
     let(:stdout) { StringIO.new }
     let(:stderr) { StringIO.new }
 


### PR DESCRIPTION
getting sick of these ...
```
Error 512 during PUT /api/v1/monitor/2233
{"errors":["Timeout"]}
```