### PR TITLE
support using sli_specification

### DIFF
--- a/lib/kennel/models/project.rb
+++ b/lib/kennel/models/project.rb
@@ -10,10 +10,16 @@ module Kennel
 
       def self.file_location
         return @file_location if defined?(@file_location)
-        if (location = instance_methods(false).first)
-          @file_location = force_relative_path(instance_method(location).source_location.first)
+        methods = instance_methods(false)
+        if methods.any?
+          @file_location = methods.detect do |method|
+            location = instance_method(method).source_location.first
+            if (path = find_relative_path(location))
+              break path
+            end
+          end || raise("Unable to find file_location for #{name}")
         else
-          @file_location = nil
+          @file_location = nil # not sure if this is actually needed
         end
       end
 
@@ -29,11 +35,9 @@ module Kennel
 
       private
 
-      private_class_method def self.force_relative_path(path)
+      private_class_method def self.find_relative_path(path)
         return path unless File.absolute_path?(path)
-        path.dup.sub!("#{Bundler.root}/", "") ||
-          path.dup.sub!("#{Dir.pwd}/", "") ||
-          raise("Unable to make path #{path} relative with bundler root #{Bundler.root} or pwd #{Dir.pwd}")
+        path.dup.sub!("#{Bundler.root}/", "") || path.dup.sub!("#{Dir.pwd}/", "")
       end
 
       # hook for users to add custom filtering via `prepend`

--- a/lib/kennel/models/slo.rb
+++ b/lib/kennel/models/slo.rb
@@ -15,7 +15,8 @@ module Kennel
         groups: nil,
         monitor_ids: [],
         thresholds: [],
-        primary: nil
+        primary: nil,
+        sli_specification: nil
       }.freeze
 
       settings :type, :description, :thresholds, :query, :tags, :monitor_ids, :monitor_tags, :name, :groups, :sli_specification, :primary
@@ -27,7 +28,8 @@ module Kennel
         monitor_ids: -> { DEFAULTS.fetch(:monitor_ids) },
         thresholds: -> { DEFAULTS.fetch(:thresholds) },
         groups: -> { DEFAULTS.fetch(:groups) },
-        primary: -> { DEFAULTS.fetch(:primary) }
+        primary: -> { DEFAULTS.fetch(:primary) },
+        sli_specification: -> { DEFAULTS.fetch(:sli_specification) }
       )
 
       def build_json
@@ -50,9 +52,8 @@ module Kennel
           data[:target_threshold] = threshold[:target]
         end
 
-        # TODO: if user set sli_specification but we don't use it we should raise, but sadly we can't detect that easily
-        if type == "time_slice"
-          data[:sli_specification] = sli_specification
+        if (v = sli_specification)
+          data[:sli_specification] = v
         elsif (v = query)
           data[:query] = v
         end
@@ -102,10 +103,11 @@ module Kennel
           [:timeframe, :warning_threshold, :target_threshold].each { |k| actual.delete k }
         end
 
-        # datadog always sets this, but we only set it for time_slice, so discard it for everything else to avoid diff
-        if expected[:type] != "time_slice"
-          actual.delete :sli_specification
-        end
+        # discard deprecated query which stays in datadog forever when we are trying to
+        # set sli_specification or are importing sli_specification
+        # (downgrading to query by setting sli_specification=nil is not supported in the api)
+        actual.delete :query if expected[:sli_specification] || (expected.empty? && actual[:sli_specification])
+        actual.delete :sli_specification if expected[:query] # uncovered TODO: this might be a bug, once sli_specification is set query does not override it
 
         ignore_default(expected, actual, DEFAULTS)
       end

--- a/test/kennel/models/slo_test.rb
+++ b/test/kennel/models/slo_test.rb
@@ -309,20 +309,28 @@ describe Kennel::Models::Slo do
     end
 
     describe "sli_specification" do
-      it "diffs remote for time_slice" do
-        expected = { type: "time_slice", tags: [], sli_specification: 1 }
-        actual = { type: "time_slice", tags: [], sli_specification: 2 }
+      it "diffs remote" do
+        expected = { tags: [], sli_specification: 1 }
+        actual = { tags: [], sli_specification: 2 }
         Kennel::Models::Slo.normalize(expected, actual)
-        expected.must_equal(type: "time_slice", tags: [], sli_specification: 1)
-        actual.must_equal(type: "time_slice", tags: [], sli_specification: 2)
+        expected.must_equal(tags: [], sli_specification: 1)
+        actual.must_equal(tags: [], sli_specification: 2)
       end
 
-      it "ignores remote for non time_slice" do
-        expected = { tags: [] }
-        actual = { sli_specification: 1, tags: [] }
+      it "ignores query when not set" do
+        expected = { tags: [], sli_specification: 1 }
+        actual = { query: 2, sli_specification: 1, tags: [] } # query will always stay in dd api
         Kennel::Models::Slo.normalize(expected, actual)
-        expected.must_equal(tags: [])
-        actual.must_equal(tags: [])
+        expected.must_equal(tags: [], sli_specification: 1)
+        actual.must_equal(tags: [], sli_specification: 1)
+      end
+
+      it "shows when importing" do
+        expected = {}
+        actual = { tags: [], query: 2, sli_specification: 2 }
+        Kennel::Models::Slo.normalize(expected, actual)
+        expected.must_equal({})
+        actual.must_equal(tags: [], sli_specification: 2)
       end
     end
   end


### PR DESCRIPTION
the way dd seems to work is that once sli_specification is set you need to keep using it since query is then ignored
also we had non time_slice slos now using sli_specification

<img width="733" height="155" alt="image" src="https://github.com/user-attachments/assets/5cbc6f2e-682e-4017-8bc6-c813fec98dd1" />

- show sli_specification when importing to encourage using the new format
- when sli_specification is set only send that
- when query is set only send that ... which is not great because if a slo was migrated to "bad events" then the query will be completely ignored ... but if it was created with just sli_specification everything works fine and afaik there is no way to tell what is what
