### PR TITLE
feat(dashboard): add groups_as_tabs option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -267,6 +267,7 @@ Remove the code that created the resource. The next update will delete it (see a
             kennel_id: -> { "overview-dashboard" }, # make up a unique name
             layout_type: -> { "ordered" },
             widgets: -> { "... raw widget definitions, most flexible ..." },
+            groups_as_tabs: -> { true }, # optional: one tab per top-level group widget, named from group title
             definitions: -> {
               [ # each element is a graph in the dashboard, alternatively a hash for complete control just like in `widgets`
                 [

--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -56,6 +56,7 @@ module Kennel
 
     def update(api_resource, id, attributes)
       restore_widget_ids(id, attributes) if api_resource == "dashboard"
+      restore_groups_as_tabs(id, attributes) if api_resource == "dashboard"
 
       response = request :put, "/api/v1/#{api_resource}/#{id}", body: attributes
       response[:id] = response.delete(:public_id) if api_resource == "synthetics/tests"
@@ -100,6 +101,32 @@ module Kennel
       each_widget_with_key(widgets) do |key, widget|
         next unless (id = ids[key])
         widget[:id] ||= id # do not set nil, that breaks updates
+      end
+    end
+
+    # groups_as_tabs uses @N refs on create; on update Datadog needs tab ids and real widget ids in tabs
+    def restore_groups_as_tabs(id, attributes)
+      tabs = attributes[:tabs]
+      return unless tabs&.any?
+
+      widgets = attributes[:widgets]
+      return unless widgets&.any?
+      return unless (current = show("dashboard", id, {}, ignore_404: true))
+
+      current_tabs = current[:tabs] || []
+      current_tabs_by_name = current_tabs.to_h { |tab| [tab.fetch(:name), tab] }
+
+      tabs.each_with_index do |tab, index|
+        name = tab.fetch(:name)
+        current_tab = current_tabs[index] if current_tabs[index]&.fetch(:name) == name
+        current_tab ||= current_tabs_by_name[name]
+        tab[:id] = current_tab.fetch(:id) if current_tab&.fetch(:id)
+
+        widget_id = tab.fetch(:widget_ids).first
+        if widget_id.is_a?(String) && widget_id.start_with?("@")
+          widget_id = widgets.fetch(widget_id.delete_prefix("@").to_i - 1).fetch(:id)
+        end
+        tab[:widget_ids] = [widget_id]
       end
     end
 

--- a/lib/kennel/models/dashboard.rb
+++ b/lib/kennel/models/dashboard.rb
@@ -77,7 +77,7 @@ module Kennel
 
       settings(
         :title, :description, :definitions, :widgets, :layout_type, :template_variable_presets, :reflow_type,
-        :tags
+        :tags, :groups_as_tabs
       )
 
       defaults(
@@ -86,7 +86,8 @@ module Kennel
         widgets: -> { [] },
         template_variable_presets: -> { DEFAULTS.fetch(:template_variable_presets) },
         reflow_type: -> { layout_type == "ordered" ? "auto" : nil },
-        tags: -> { project.tags }
+        tags: -> { project.tags },
+        groups_as_tabs: -> { false }
       )
 
       class << self
@@ -106,6 +107,8 @@ module Kennel
             ignore_request_defaults(*pair)
             pair.each { |widget| widget&.delete(:id) } # ids change on every update so we always discard them
           end
+
+          [expected, actual].each { |data| data.delete(:tabs) }
         end
 
         private
@@ -165,7 +168,23 @@ module Kennel
 
         json[:reflow_type] = reflow_type if reflow_type # setting nil breaks create with "ordered"
 
+        json[:tabs] = groups_as_tabs_json(all_widgets) if groups_as_tabs
+
         json
+      end
+
+      def diff(actual)
+        expected = as_json.dup
+        actual = actual.dup
+        expected.delete(:id)
+
+        self.class.normalize(expected, actual)
+
+        return [] if actual == expected
+
+        result = Hashdiff.diff(actual, expected, use_lcs: false, strict: false, similarity: 1)
+        raise "Empty diff detected: guard condition failed" if result.empty?
+        result
       end
 
       def self.url(id)
@@ -215,6 +234,13 @@ module Kennel
       end
 
       private
+
+      def groups_as_tabs_json(widgets)
+        widgets.each_with_index.map do |widget, index|
+          title = widget.fetch(:definition).fetch(:title)
+          { name: title, widget_ids: ["@#{index + 1}"] }
+        end
+      end
 
       # creates queries from metadata to avoid having to keep q and expression in sync
       #

--- a/test/kennel/api_test.rb
+++ b/test/kennel/api_test.rb
@@ -254,6 +254,37 @@ describe Kennel::Api do
           .to_return(body: "{}")
         api.update("dashboard", 123, expected)
       end
+
+      it "resolves groups_as_tabs refs for update" do
+        stub_datadog_request(:get, "dashboard/123").to_return(
+          body: {
+            widgets: [
+              { id: 111, definition: { title: "One", type: "group" } },
+              { id: 222, definition: { title: "Two", type: "group" } },
+            ],
+            tabs: [{ id: "tab-1", name: "One", widget_ids: [111] }]
+          }.to_json
+        )
+        expected = {
+          widgets: [
+            { definition: { title: "One", type: "group" } },
+            { definition: { title: "Two", type: "group" } },
+          ],
+          tabs: [
+            { name: "One", widget_ids: ["@1"] },
+            { name: "Two", widget_ids: ["@2"] },
+          ]
+        }
+        stub_datadog_request(:put, "dashboard/123") do |request|
+          body = JSON.parse(request.body, symbolize_names: true)
+          body[:widgets].map { |w| w[:id] }.must_equal [111, 222]
+          body[:tabs].must_equal [
+            { id: "tab-1", name: "One", widget_ids: [111] },
+            { name: "Two", widget_ids: [222] },
+          ]
+        end.to_return(body: "{}")
+        api.update("dashboard", 123, expected)
+      end
     end
   end
 

--- a/test/kennel/models/dashboard_test.rb
+++ b/test/kennel/models/dashboard_test.rb
@@ -381,6 +381,34 @@ describe Kennel::Models::Dashboard do
     end
   end
 
+  describe "with groups_as_tabs" do
+    it "adds tabs with 1-indexed positional widget refs" do
+      group_widgets = [
+        { definition: { title: "One", type: "group", layout_type: "ordered", widgets: [] } },
+        { definition: { title: "Two", type: "group", layout_type: "ordered", widgets: [] } },
+      ]
+      tabbed = dashboard(groups_as_tabs: -> { true }, widgets: -> { group_widgets })
+      tabbed.build_json[:tabs].must_equal(
+        [
+          { name: "One", widget_ids: ["@1"] },
+          { name: "Two", widget_ids: ["@2"] },
+        ]
+      )
+    end
+
+    it "ignores tabs when diffing" do
+      group_widgets = [{ definition: { title: "One", type: "group", layout_type: "ordered", widgets: [] } }]
+      dash = dashboard(groups_as_tabs: -> { true }, widgets: -> { group_widgets })
+      dash.build
+      actual = dash.as_json.dup.merge(
+        tabs: [{ id: "tab-1", name: "One", widget_ids: [111] }],
+        widgets: [{ id: 111, definition: { title: "One", type: "group", layout_type: "ordered", widgets: [] } }]
+      )
+      dash.diff(actual).must_equal []
+      dash.as_json[:tabs].must_equal [{ name: "One", widget_ids: ["@1"] }]
+    end
+  end
+
   describe ".normalize" do
     it "can clean up import" do
       actual = expected_json_with_requests


### PR DESCRIPTION
## Summary

- Add `groups_as_tabs: true` for dashboards where each top-level group widget becomes one tab (named from `definition.title`)
- Emit `tabs` with `@N` positional refs on create; resolve to real ids in `Api#update` (alongside #382 widget id restore)
- Ignore `tabs` during diff since they are derived from widgets

Prototype: [zendesk/kennel#34514](https://github.com/zendesk/kennel/pull/34514)

Depends on #382 for widget id preservation on update.

## Usage

```ruby
defaults(
  groups_as_tabs: true,
  layout_type: -> { "ordered" },
  widgets: -> { [overview_group, api_server_group, ...] }
)
```

## Checklist

- [x] Verified against local install of kennel (using `path:` in Gemfile)
- [x] Added tests
- [x] Updated Readme.md

## Test plan

- [x] `bundle exec rake test`
- [ ] Create dashboard with `groups_as_tabs: true`
- [ ] Update existing dashboard to add `groups_as_tabs: true`
- [ ] Verify consecutive updates do not churn widget/tab ids
