### PR TITLE
fix dashboards unable to get their details filled breaking the run

### DIFF
--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -117,26 +117,13 @@ module Kennel
       cached = (ENV["FORCE_GET_CACHE"] && method == :get)
 
       with_cache cached, path do
-        response = nil
-        tries.times do |i|
-          response = Utils.retry Faraday::ConnectionFailed, Faraday::TimeoutError, times: 2 do
-            @client.send(method, path) do |request|
-              request.body = JSON.generate(body) if body
-              request.headers["Content-type"] = "application/json"
-              request.headers["DD-API-KEY"] = @api_key
-              request.headers["DD-APPLICATION-KEY"] = @app_key
-            end
+        response = request_with_retries(path, tries) do
+          @client.send(method, path) do |request|
+            request.body = JSON.generate(body) if body
+            request.headers["Content-type"] = "application/json"
+            request.headers["DD-API-KEY"] = @api_key
+            request.headers["DD-APPLICATION-KEY"] = @app_key
           end
-
-          if response.status == 429
-            sleep_until_rate_limit_resets(response)
-            redo
-          end
-
-          last_try = (i == tries - 1)
-          break if last_try || response.status < 500
-          Kennel.err.puts "Retrying on server error #{response.status} for #{path}"
-          sleep retry_backoff_time(i)
         end
 
         next if response.status == 404 && ignore_404
@@ -154,6 +141,26 @@ module Kennel
           JSON.parse(response.body, symbolize_names: true)
         end
       end
+    end
+
+    # retry on rate-limits and server errors, giving up after `tries` attempts
+    def request_with_retries(path, tries, &block)
+      raise ArgumentError, "tries must be > 0" if tries < 1
+      response = nil
+      tries.times do |i|
+        response = Utils.retry Faraday::ConnectionFailed, Faraday::TimeoutError, times: 2, &block
+
+        if response.status == 429
+          sleep_until_rate_limit_resets(response)
+          redo
+        end
+
+        last_try = (i == tries - 1)
+        break if last_try || response.status < 500
+        Kennel.err.puts "Retrying on server error #{response.status} for #{path}"
+        sleep retry_backoff_time(i)
+      end
+      response
     end
 
     def sleep_until_rate_limit_resets(response)

--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -139,7 +139,9 @@ module Kennel
           sleep retry_backoff_time(i)
         end
 
-        if !response.success? && (response.status != 404 || !ignore_404)
+        next if response.status == 404 && ignore_404
+
+        unless response.success?
           message = "Error #{response.status} during #{method.upcase} #{path}\n"
           message << "request:\n#{JSON.pretty_generate(body)}\nresponse:\n" if body
           message << response.body.encode(message.encoding, invalid: :replace, undef: :replace)

--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -157,6 +157,8 @@ module Kennel
       tries.times do |i|
         response = Utils.retry Faraday::ConnectionFailed, Faraday::TimeoutError, times: 2, &block
 
+        # we do not count 429s into the "tries", tries are only for real errors
+        # so this could loop forever if datadog consistently 429s
         if response.status == 429
           sleep_until_rate_limit_resets(response)
           redo

--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -22,8 +22,9 @@ module Kennel
       @client = Faraday.new(url: url)
     end
 
-    def show(api_resource, id, params = {})
-      response = request :get, "/api/v1/#{api_resource}/#{id}", params: params
+    def show(api_resource, id, params = {}, ignore_404: false)
+      response = request :get, "/api/v1/#{api_resource}/#{id}", params: params, ignore_404: ignore_404
+      return if response.nil? # 404 that was ignored
       response = response.fetch(:data) if api_resource == "slo"
       response[:id] = response.delete(:public_id) if api_resource == "synthetics/tests"
       self.class.with_tracking(api_resource, response)
@@ -74,7 +75,12 @@ module Kennel
     # fill the resource with the full response from the `show` if `list` does not return it
     def fill_details!(api_resource, list)
       details_cache do |cache|
-        Utils.parallel(list) { |a| fill_detail!(api_resource, a, cache) }.sum
+        results = Utils.parallel(list) { |a| fill_detail!(api_resource, a, cache) }
+
+        # drop resources that were not found (race condition between listing and showing)
+        list.select!.with_index { |_, i| results[i][1] }
+
+        results.count { |uncached, _| uncached }
       end
     end
 
@@ -96,15 +102,16 @@ module Kennel
     end
 
     # Make diff work even though we cannot mass-fetch definitions
+    # @return [uncached, found]
     def fill_detail!(api_resource, a, cache)
-      uncached = 0
+      uncached = false
       args = [api_resource, a.fetch(:id)]
       full = cache.fetch(args, a.fetch(:modified_at)) do
-        uncached += 1
-        show(*args)
+        uncached = true
+        show(*args, ignore_404: true)
       end
-      a.merge!(full)
-      uncached
+      a.merge!(full) if full
+      [uncached, !!full]
     end
 
     def details_cache(&block)

--- a/test/kennel/api_test.rb
+++ b/test/kennel/api_test.rb
@@ -67,7 +67,7 @@ describe Kennel::Api do
       stub_datadog_request(:get, "monitor/1234", "&foo=bar")
         .with(body: nil, headers: { "Content-Type" => "application/json" })
         .to_return(body: { bar: "foo" }.to_json)
-      api.show("monitor", 1234, foo: "bar").must_equal(bar: "foo", klass: Kennel::Models::Monitor, tracking_id: nil)
+      api.show("monitor", 1234, { foo: "bar" }).must_equal(bar: "foo", klass: Kennel::Models::Monitor, tracking_id: nil)
     end
 
     it "does not ignore 404" do
@@ -266,6 +266,14 @@ describe Kennel::Api do
       api.fill_details!("dashboard", [{ id: "123", modified_at: "1" }])
       api.fill_details!("dashboard", [{ id: "123", modified_at: "1" }]).must_equal 0
     end
+
+    it "drops dashboards that were deleted between list and show" do
+      stub_datadog_request(:get, "dashboard/123").to_return(body: { bar: "foo" }.to_json)
+      stub_datadog_request(:get, "dashboard/456").to_return(status: 404)
+      list = [{ id: "123", modified_at: "1" }, { id: "456", modified_at: "1" }]
+      api.fill_details!("dashboard", list).must_equal 2
+      list.must_equal [{ id: "123", klass: Kennel::Models::Dashboard, tracking_id: nil, modified_at: "1", bar: "foo" }]
+    end
   end
 
   describe "rate limiting" do
@@ -351,6 +359,11 @@ describe Kennel::Api do
       end
       assert_requested request, times: 3
       stderr.string.scan(/\d retries left/).must_equal ["1 retries left", "0 retries left"]
+    end
+
+    it "fails when no request would be made" do
+      e = assert_raises(ArgumentError) { api.send(:request_with_retries, "/x", 0) {} }
+      e.message.must_equal "tries must be > 0"
     end
 
     it "fails on repeated errors" do

--- a/test/kennel/api_test.rb
+++ b/test/kennel/api_test.rb
@@ -220,7 +220,7 @@ describe Kennel::Api do
 
     it "ignores 404" do
       stub_datadog_request(:delete, "monitor/123", "&force=true").to_return(status: 404)
-      api.delete("monitor", 123).must_equal({})
+      api.delete("monitor", 123).must_be_nil
     end
   end
 


### PR DESCRIPTION
we can list dashboards and then some might get deleted a second later, so filling their details crashes
instead remove them from the list

```
 Error 404 during GET /api/v1/dashboard/xma-wus-vgb
  {"errors":["Dashboard with ID xma-wus-vgb not found"]}
  /home/runner/_work/kennel/kennel/vendor/bundle/ruby/4.0.0/gems/kennel-2.21.0/lib/kennel/api.rb:146:in 'block in Kennel::Api#request'
  /home/runner/_work/kennel/kennel/vendor/bundle/ruby/4.0.0/gems/kennel-2.21.0/lib/kennel/api.rb:179:in 'Kennel::Api#with_cache'
  /home/runner/_work/kennel/kennel/vendor/bundle/ruby/4.0.0/gems/kennel-2.21.0/lib/kennel/api.rb:119:in 'Kennel::Api#request'
  /home/runner/_work/kennel/kennel/vendor/bundle/ruby/4.0.0/gems/kennel-2.21.0/lib/kennel/api.rb:26:in 'Kennel::Api#show'
  /home/runner/_work/kennel/kennel/vendor/bundle/ruby/4.0.0/gems/kennel-2.21.0/lib/kennel/api.rb:104:in 'block in Kennel::Api#fill_detail!'
  /home/runner/_work/kennel/kennel/vendor/bundle/ruby/4.0.0/gems/kennel-2.21.0/lib/kennel/file_cache.rb:32:in 'Kennel::FileCache#fetch'
  /home/runner/_work/kennel/kennel/vendor/bundle/ruby/4.0.0/gems/kennel-2.21.0/lib/kennel/api.rb:102:in 'Kennel::Api#fill_detail!'
  /home/runner/_work/kennel/kennel/vendor/bundle/ruby/4.0.0/gems/kennel-2.21.0/lib/kennel/api.rb:77:in 'block (2 levels) in Kennel::Api#fill_details!'
  /home/runner/_work/kennel/kennel/vendor/bundle/ruby/4.0.0/gems/kennel-2.21.0/lib/kennel/utils.rb:31:in 'block (3 levels) in Kennel::Utils.parallel'
```