### PR TITLE
preserve dashboard ids when updating dashboards

### DIFF
--- a/lib/kennel/api.rb
+++ b/lib/kennel/api.rb
@@ -55,6 +55,8 @@ module Kennel
     end
 
     def update(api_resource, id, attributes)
+      restore_widget_ids(id, attributes) if api_resource == "dashboard"
+
       response = request :put, "/api/v1/#{api_resource}/#{id}", body: attributes
       response[:id] = response.delete(:public_id) if api_resource == "synthetics/tests"
       self.class.with_tracking(api_resource, response)
@@ -85,6 +87,33 @@ module Kennel
     end
 
     private
+
+    # keep widget ids stable so stored dashboard urls that point at a widget do not break on every update
+    # widget ids are dropped when diffing since they change on every update, but that also changes them in datadog
+    # and breaks stored urls that point at a specific widget, so restore the previous ids by matching widget titles
+    def restore_widget_ids(id, attributes)
+      return unless (widgets = attributes[:widgets])
+      return unless (current = show("dashboard", id, {}, ignore_404: true))
+
+      ids = {}
+      each_widget_with_key(current[:widgets]) { |key, widget| ids[key] = widget[:id] }
+      each_widget_with_key(widgets) do |key, widget|
+        next unless (id = ids[key])
+        widget[:id] ||= id # do not set nil, that breaks updates
+      end
+    end
+
+    # yield each widget with a key built from its (optional) group title and its own title
+    def each_widget_with_key(widgets, prefix: nil, &block)
+      widgets.each do |widget|
+        title = widget.dig(:definition, :title)
+        key = [prefix, title].compact.join("-")
+        yield key, widget
+        if (nested = widget.dig(:definition, :widgets))
+          each_widget_with_key(nested, prefix: title, &block)
+        end
+      end
+    end
 
     def with_pagination(enabled, params)
       return yield params unless enabled

--- a/test/kennel/api_test.rb
+++ b/test/kennel/api_test.rb
@@ -187,6 +187,74 @@ describe Kennel::Api do
       stub_datadog_request(:put, "synthetics/tests/123").to_return(body: { public_id: "123" }.to_json)
       api.update("synthetics/tests", "123", foo: "bar").must_equal(id: "123", klass: Kennel::Models::SyntheticTest, tracking_id: nil)
     end
+
+    describe "dashboard widget ids" do
+      it "restores widget ids by title" do
+        stub_datadog_request(:get, "dashboard/123").to_return(
+          body: { widgets: [{ id: 111, definition: { title: "Bar" } }] }.to_json
+        )
+        expected = { widgets: [{ definition: { title: "Bar" } }] }
+        stub_datadog_request(:put, "dashboard/123")
+          .with(body: { widgets: [{ definition: { title: "Bar" }, id: 111 }] }.to_json)
+          .to_return(body: "{}")
+        api.update("dashboard", 123, expected)
+      end
+
+      it "restores nested widget ids using the group title" do
+        stub_datadog_request(:get, "dashboard/123").to_return(
+          body: {
+            widgets: [{ id: 1, definition: { title: "Foo", widgets: [{ id: 222, definition: { title: "Bar" } }] } }]
+          }.to_json
+        )
+        expected = { widgets: [{ definition: { title: "Foo", widgets: [{ definition: { title: "Bar" } }] } }] }
+        stub_datadog_request(:put, "dashboard/123")
+          .with(
+            body: {
+              widgets: [{ definition: { title: "Foo", widgets: [{ definition: { title: "Bar" }, id: 222 }] }, id: 1 }]
+            }.to_json
+          )
+          .to_return(body: "{}")
+        api.update("dashboard", 123, expected)
+      end
+
+      it "keeps explicitly set widget ids" do
+        stub_datadog_request(:get, "dashboard/123").to_return(
+          body: { widgets: [{ id: 111, definition: { title: "Bar" } }] }.to_json
+        )
+        expected = { widgets: [{ id: 999, definition: { title: "Bar" } }] }
+        stub_datadog_request(:put, "dashboard/123")
+          .with(body: { widgets: [{ id: 999, definition: { title: "Bar" } }] }.to_json)
+          .to_return(body: "{}")
+        api.update("dashboard", 123, expected)
+      end
+
+      it "leaves widgets without a matching title untouched" do
+        stub_datadog_request(:get, "dashboard/123").to_return(
+          body: { widgets: [{ id: 111, definition: { title: "Bar" } }] }.to_json
+        )
+        expected = { widgets: [{ definition: { title: "New" } }] }
+        stub_datadog_request(:put, "dashboard/123")
+          .with(body: { widgets: [{ definition: { title: "New" } }] }.to_json)
+          .to_return(body: "{}")
+        api.update("dashboard", 123, expected)
+      end
+
+      it "does nothing when there are no widgets" do
+        stub_datadog_request(:put, "dashboard/123")
+          .with(body: { title: "Foo" }.to_json)
+          .to_return(body: "{}")
+        api.update("dashboard", 123, title: "Foo")
+      end
+
+      it "does nothing when the current dashboard is gone" do
+        stub_datadog_request(:get, "dashboard/123").to_return(status: 404)
+        expected = { widgets: [{ definition: { title: "Bar" } }] }
+        stub_datadog_request(:put, "dashboard/123")
+          .with(body: { widgets: [{ definition: { title: "Bar" } }] }.to_json)
+          .to_return(body: "{}")
+        api.update("dashboard", 123, expected)
+      end
+    end
   end
 
   describe "#delete" do


### PR DESCRIPTION
otherwise stored urls (from someone opening a widget) stop working
we'll also need this for tabs to work in the future